### PR TITLE
feat: implement --separate, expose --no-vad, name the unmatched lines (v0.2.0)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ venv/
 *.wav
 *.mp3
 *.flac
+*.ogg
+demo_local/

--- a/README.md
+++ b/README.md
@@ -17,9 +17,12 @@ It is built for two things most aligners handle poorly:
 
 ## Install
 
+Not on PyPI yet — install from source:
+
 ```bash
-pip install lyric-align          # core (pure stdlib, no heavy deps)
-pip install lyric-align[asr]      # + faster-whisper, to transcribe audio
+pip install "git+https://github.com/ijuinryukichi/lyric-align"           # core (pure stdlib)
+pip install "lyric-align[asr] @ git+https://github.com/ijuinryukichi/lyric-align"        # + faster-whisper (transcribe)
+pip install "lyric-align[asr,separate] @ git+https://github.com/ijuinryukichi/lyric-align"  # + demucs (vocal split)
 ```
 
 ## Use
@@ -28,6 +31,9 @@ pip install lyric-align[asr]      # + faster-whisper, to transcribe audio
 # transcribe audio and align known lyrics → LRC
 lyric-align song.wav lyrics.txt -o out.lrc
 
+# full mix? split the vocal first — this matters a lot (see below)
+lyric-align song.wav lyrics.txt --separate -o out.lrc
+
 # already have Whisper segments? skip ASR
 lyric-align --segments segments.json lyrics.txt -f srt
 
@@ -35,9 +41,61 @@ lyric-align --segments segments.json lyrics.txt -f srt
 lyric-align song.wav lyrics.txt -f ass --karaoke -o out.ass
 ```
 
-`lyrics.txt` is plain text, one lyric line per line. `segments.json` is a list
-of `{"start", "end", "text", "words": [{"start","end","word"}]}` — the shape any
+`lyrics.txt` is plain text, one lyric line per line. Blank lines, `# comments`
+and section markers (`[Verse 1]`, `[Hook]`) are skipped, so a pasted lyric sheet
+works as-is. `segments.json` is a list of
+`{"start", "end", "text", "words": [{"start","end","word"}]}` — the shape any
 Whisper flavor produces.
+
+### Try it in one minute
+
+Both the recording and the lyrics below are public domain, so this runs
+end-to-end with nothing of your own:
+
+```bash
+curl -L -o amazing_grace.mp3 \
+  "https://upload.wikimedia.org/wikipedia/commons/8/8f/Amazing_Grace_%28vocalist_with_guitar%29_-_Southern_Aire_-_United_States_Air_Force_Reserve_Band.mp3"
+# examples/amazing_grace.txt ships with this repo
+lyric-align amazing_grace.mp3 examples/amazing_grace.txt \
+  --language en --pairing 1 --no-vad -o amazing_grace.lrc
+```
+
+```
+segments: 12
+aligned 9/12 lines
+unmatched (omitted from output) — check these lines:
+  line 10: sim 0.00  I have already come
+  line 11: sim 0.00  Tis grace hath brought me safe thus far
+  line 12: sim 0.00  And grace will lead me home
+```
+
+```
+[00:06.60]Amazing grace, how sweet the sound
+[00:14.30]That saved a wretch like me
+[00:23.70]I once was lost, but now am found
+[00:34.52]Was blind, but now I see
+```
+
+Note `--no-vad`: this is a slow hymn, and the ASR's voice-activity filter
+mistakes sustained singing for silence. With the filter on, the same file yields
+**one** garbage segment for 130 seconds; with it off, twelve clean ones. Keep the
+filter for rap, drop it for anything sung slowly. (`--pairing 1` because this ASR
+already split one lyric line per segment.)
+
+### Feed it a vocal stem
+
+Alignment quality is dominated by this one choice. Same track, same settings,
+20 human-marked lines — only the input differs:
+
+| input | matched | mean \|err\| |
+|---|---|---|
+| Demucs vocal stem | **19/20** | **0.50 s** |
+| full mix | 8/20 | 1.59 s |
+
+On the full mix the ASR returned 11 segments for a 4-minute song instead of 41,
+merging whole sections, and everything past the first chorus went unmatched. Use
+`--separate` (or point the tool at a stem you already have). Separation is the
+slow step, so the stem is cached and reused.
 
 ### Library
 
@@ -90,6 +148,31 @@ Both `lyric-align` and `stable-ts` reach the ±0.5 s noise floor of the human
 ground truth — i.e. practically equivalent accuracy. WhisperX's batched VAD
 merges whole verses into single segments, which is fine for captions but loses
 line-level timing (and it can't take known text as input).
+
+A second track (3-minute Japanese rap, 33 human-marked lines, 1 s ground-truth
+granularity) reproduces this: **33/33 matched, median |err| 0.30 s**, 26/33
+within 0.5 s. Its mean of 0.94 s comes almost entirely from four outliers, all on
+the *same* line — see below.
+
+## Known limits
+
+- **Heavily repeated refrains can land on the wrong repetition.** A hook line
+  sung four times is four identical strings; if the ASR segments the repeats
+  unevenly, the forward scan can consume the neighbouring one. On the track
+  above, one 4×-repeated hook line produced errors of +6.4 s, −3.8 s, −4.5 s and
+  +5.7 s while every non-repeated line stayed within ~0.5 s. Check hook sections
+  by hand, or align verses and hooks as separate passes.
+- **Slow, sustained singing is much harder than rap** — hymns, ballads and
+  school songs stretch vowels until the ASR stops producing usable segments.
+  Reach for `--no-vad` first (see the one-minute example); dense, consonant-rich
+  delivery is the sweet spot. This is an ASR limit, not an anchoring one.
+- **A quiet or lo-fi recording can defeat the ASR entirely.** On a −33 dBFS
+  amateur recording of an unaccompanied Japanese art song, Whisper returned zero
+  segments, and returned `音楽` ("music") or a row of repeated single characters
+  once its silence thresholds were relaxed — it classified the singing as music
+  rather than speech. Loudness-normalizing to −16 LUFS did not help. When the
+  transcription is empty there is nothing to anchor to; check for segments before
+  blaming the alignment.
 
 The nearest match, [stable-ts](https://github.com/jianfch/stable-ts), was
 **archived in 2026-05**. `lyric-align` is a lighter (`ctranslate2`, not

--- a/examples/amazing_grace.txt
+++ b/examples/amazing_grace.txt
@@ -1,0 +1,14 @@
+Amazing grace, how sweet the sound
+That saved a wretch like me
+I once was lost, but now am found
+Was blind, but now I see
+
+Twas grace that taught my heart to fear
+And grace my fears relieved
+How precious did that grace appear
+The hour I first believed
+
+Through many dangers, toils and snares
+I have already come
+Tis grace hath brought me safe thus far
+And grace will lead me home

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "lyric-align"
-version = "0.1.0"
+version = "0.2.0"
 description = "Place known lyrics on an audio timeline — CJK-first, built for sung vocals and rap."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/lyric_align/__init__.py
+++ b/src/lyric_align/__init__.py
@@ -9,7 +9,7 @@ from .anchor import align, interpolate_gaps
 from .model import AlignedLine, Segment, Word
 from .normalize import normalize, similarity
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"
 
 __all__ = [
     "align", "interpolate_gaps",

--- a/src/lyric_align/cli.py
+++ b/src/lyric_align/cli.py
@@ -1,14 +1,17 @@
 """Command-line interface.
 
     lyric-align AUDIO LYRICS.txt -o out.lrc          # transcribe + align
+    lyric-align AUDIO LYRICS.txt --separate -o o.lrc  # split vocals first (better)
     lyric-align --segments segs.json LYRICS.txt -f ass --karaoke
 
-LYRICS is a plain-text file, one lyric line per line; blank lines are ignored.
+LYRICS is a plain-text file, one lyric line per line. Blank lines and section
+markers ([Verse 1], [Hook]) are ignored, so pasted lyric sheets work as-is.
 """
 from __future__ import annotations
 
 import argparse
 import json
+import re
 import sys
 from pathlib import Path
 
@@ -17,9 +20,18 @@ from .anchor import align, interpolate_gaps
 from .formats import FORMATTERS
 from .model import Segment
 
+SECTION_MARKER = re.compile(r"^[\[(](?:[^\[\]()]{0,40})[\])]$")
+
 
 def read_lyrics(path: Path) -> list[str]:
-    return [ln.strip() for ln in path.read_text().splitlines() if ln.strip()]
+    """One lyric line per line; drop blanks, section markers and # comments."""
+    out = []
+    for raw in path.read_text().splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#") or SECTION_MARKER.match(line):
+            continue
+        out.append(line)
+    return out
 
 
 def load_segments(path: Path) -> list[Segment]:
@@ -35,6 +47,9 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument("-f", "--format", default=None,
                    choices=sorted(FORMATTERS), help="output format (default: infer from -o, else json)")
     p.add_argument("--segments", help="pre-computed segments JSON (skip ASR)")
+    p.add_argument("--separate", action="store_true",
+                   help="split the vocal stem with Demucs first (needs [separate]); "
+                        "slow but clearly more accurate on a full mix")
     p.add_argument("--pairing", type=int, default=2,
                    help="lyric lines per stanza unit (default 2; use 1 if ASR splits per line)")
     p.add_argument("--threshold", type=float, default=0.25)
@@ -45,20 +60,67 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument("--language", default="ja")
     p.add_argument("--model", default="medium", help="faster-whisper model size")
     p.add_argument("--device", default="cpu")
+    p.add_argument("--no-vad", dest="vad", action="store_false",
+                   help="disable the ASR voice-activity filter. The filter helps on dense "
+                        "delivery (rap) but silences slow, sustained singing — if you get "
+                        "few or no segments, try this first")
+    p.add_argument("-q", "--quiet", action="store_true", help="suppress progress reporting")
     p.add_argument("--version", action="version", version=f"%(prog)s {__version__}")
     return p
 
 
 def main(argv=None) -> int:
     args = build_parser().parse_args(argv)
+
+    def log(msg: str) -> None:
+        if not args.quiet:
+            print(msg, file=sys.stderr)
+
+    for label, path in (("lyrics", args.lyrics), ("audio", args.audio),
+                        ("segments", args.segments)):
+        if path and not Path(path).exists():
+            print(f"error: {label} file not found: {path}", file=sys.stderr)
+            return 2
+
     lyrics = read_lyrics(Path(args.lyrics))
+    if not lyrics:
+        print(f"error: no lyric lines found in {args.lyrics}", file=sys.stderr)
+        return 2
 
     if args.segments:
         segments = load_segments(Path(args.segments))
+        log(f"segments: {len(segments)} (from {args.segments})")
     elif args.audio:
-        from .asr import transcribe
-        segments = transcribe(args.audio, language=args.language,
-                              model_size=args.model, device=args.device)
+        audio = args.audio
+        try:
+            if args.separate:
+                from .separate import separate_vocals
+                log("separating vocals (Demucs) — this is the slow step, result is cached ...")
+                audio = separate_vocals(audio)
+                log(f"vocal stem: {audio}")
+            from .asr import transcribe
+        except ImportError as e:
+            # Missing optional extra: report the one-line install hint, not a traceback.
+            print(f"error: {e}", file=sys.stderr)
+            return 3
+        log(f"transcribing with faster-whisper ({args.model}, {args.language}"
+            f"{'' if args.vad else ', vad off'}) ...")
+        segments = transcribe(audio, language=args.language, model_size=args.model,
+                              device=args.device, vad=args.vad)
+        log(f"segments: {len(segments)}")
+        if not segments and args.vad:
+            # The voice-activity filter is tuned for dense delivery; on sustained
+            # singing it can swallow the whole track. Retry once, loudly, rather
+            # than reporting "0 lines aligned" and leaving the cause unexplained.
+            log("no segments with the voice-activity filter — retrying with --no-vad ...")
+            segments = transcribe(audio, language=args.language, model_size=args.model,
+                                  device=args.device, vad=False)
+            log(f"segments: {len(segments)}")
+        if not segments:
+            print("error: transcription produced no segments. The recording may be too "
+                  "quiet or too reverberant — try normalizing its loudness "
+                  "(ffmpeg -af loudnorm) or a larger --model.", file=sys.stderr)
+            return 1
     else:
         print("error: provide AUDIO or --segments", file=sys.stderr)
         return 2
@@ -77,11 +139,20 @@ def main(argv=None) -> int:
     text = FORMATTERS[fmt](aligned, karaoke=args.karaoke)
 
     matched = sum(1 for a in aligned if a.matched)
-    print(f"aligned {matched}/{len(aligned)} lines", file=sys.stderr)
+    log(f"aligned {matched}/{len(aligned)} lines")
+
+    # Name the gaps: the whole point of honest-gap semantics is that a human can
+    # see exactly which lines need a look, so print them rather than a bare count.
+    unmatched = [(i, a) for i, a in enumerate(aligned, 1) if not a.matched]
+    if unmatched:
+        filled = " (timestamps interpolated)" if args.interpolate else " (omitted from output)"
+        log(f"unmatched{filled} — check these lines:")
+        for i, a in unmatched:
+            log(f"  line {i}: sim {a.score:.2f}  {a.line}")
 
     if args.output:
         Path(args.output).write_text(text)
-        print(f"wrote {args.output}", file=sys.stderr)
+        log(f"wrote {args.output}")
     else:
         sys.stdout.write(text)
     return 0

--- a/src/lyric_align/separate.py
+++ b/src/lyric_align/separate.py
@@ -1,0 +1,84 @@
+"""Vocal separation via Demucs (optional dependency).
+
+Aligning against an isolated vocal stem is markedly more reliable than against a
+full mix: the ASR stops transcribing the instrumental and its word timings stop
+drifting onto drum hits. This module is a thin, cached wrapper — Demucs stays
+behind the `[separate]` extra so the core aligner keeps zero heavy dependencies.
+"""
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _pick_device() -> str:
+    """Prefer an accelerator when torch exposes one; fall back to CPU."""
+    try:
+        import torch
+    except ImportError:  # pragma: no cover - torch ships with demucs
+        return "cpu"
+    try:
+        if torch.backends.mps.is_available():
+            return "mps"
+        if torch.cuda.is_available():
+            return "cuda"
+    except AttributeError:  # pragma: no cover - older torch builds
+        pass
+    return "cpu"
+
+
+def separate_vocals(
+    audio_path: str | Path,
+    *,
+    out_dir: str | Path | None = None,
+    model: str = "htdemucs",
+    device: str | None = None,
+    overwrite: bool = False,
+) -> Path:
+    """Split `audio_path` and return the path to its vocal stem.
+
+    Requires the `[separate]` extra: pip install lyric-align[separate]
+
+    The stem is written to `<out_dir>/<model>/<stem name>/vocals.wav` (Demucs'
+    own layout) and reused on later runs unless `overwrite` is set — separation
+    is by far the slowest step, so re-running a failed alignment should not pay
+    for it twice.
+    """
+    audio_path = Path(audio_path)
+    if not audio_path.exists():
+        raise FileNotFoundError(f"audio not found: {audio_path}")
+
+    out_dir = Path(out_dir) if out_dir else audio_path.parent / "separated"
+    vocals = out_dir / model / audio_path.stem / "vocals.wav"
+    if vocals.exists() and not overwrite:
+        return vocals
+
+    if shutil.which("ffmpeg") is None and audio_path.suffix.lower() != ".wav":
+        raise RuntimeError(
+            f"ffmpeg is required to read {audio_path.suffix} files. "
+            "Install ffmpeg, or convert the input to WAV first."
+        )
+
+    try:
+        import demucs  # noqa: F401
+    except ImportError as e:
+        raise ImportError(
+            "demucs is required for vocal separation. "
+            "Install with: pip install lyric-align[separate]"
+        ) from e
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    cmd = [sys.executable, "-m", "demucs", "-n", model,
+           "--two-stems", "vocals",
+           "-d", device or _pick_device(),
+           "-o", str(out_dir), str(audio_path)]
+    subprocess.run(cmd, check=True)
+
+    if not vocals.exists():
+        raise FileNotFoundError(
+            f"Demucs finished but no vocal stem at {vocals}. "
+            f"Check the output under {out_dir}."
+        )
+    return vocals

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,70 @@
+import json
+from pathlib import Path
+
+from lyric_align.cli import main, read_lyrics
+
+FIX = Path(__file__).parent / "fixtures" / "segments_sample.json"
+
+
+def write_lyrics(tmp_path, text):
+    p = tmp_path / "lyrics.txt"
+    p.write_text(text)
+    return p
+
+
+def test_read_lyrics_skips_markers_comments_blanks(tmp_path):
+    p = write_lyrics(tmp_path, "\n".join([
+        "[Verse 1]", "", "あかねさす紫野ゆき", "# a note",
+        "(Hook)", "標野ゆき野守は見ずや", "   ",
+    ]))
+    assert read_lyrics(p) == ["あかねさす紫野ゆき", "標野ゆき野守は見ずや"]
+
+
+def test_read_lyrics_keeps_bracketed_lyric_content(tmp_path):
+    # A bracketed *lyric* (quotes, shouts) must survive; only bare section
+    # markers are dropped, so length is the discriminator we rely on.
+    p = write_lyrics(tmp_path, "「かかれぃ！」と鬼が吼え\n[Hook]\n")
+    assert read_lyrics(p) == ["「かかれぃ！」と鬼が吼え"]
+
+
+def test_cli_segments_to_lrc(tmp_path, capsys):
+    lyrics = write_lyrics(tmp_path, "あかねさす紫野ゆき\n標野ゆき野守は見ずや\n君が袖振る\n")
+    out = tmp_path / "out.lrc"
+    rc = main([str(lyrics), "--segments", str(FIX), "--pairing", "1", "-o", str(out)])
+    assert rc == 0
+    text = out.read_text()
+    assert text.startswith("[00:00.50]")
+    assert "君が袖振る" in text
+    assert "aligned 3/3 lines" in capsys.readouterr().err
+
+
+def test_cli_names_unmatched_lines(tmp_path, capsys):
+    lyrics = write_lyrics(tmp_path, "あかねさす紫野ゆき\n全く違う歌詞ここにある\n")
+    rc = main([str(lyrics), "--segments", str(FIX), "--pairing", "1",
+               "--window", "1", "-f", "json"])
+    assert rc == 0
+    err = capsys.readouterr().err
+    assert "unmatched" in err
+    assert "全く違う歌詞ここにある" in err  # the human is told *which* line to check
+
+
+def test_cli_quiet_silences_progress(tmp_path, capsys):
+    lyrics = write_lyrics(tmp_path, "あかねさす紫野ゆき\n")
+    main([str(lyrics), "--segments", str(FIX), "--pairing", "1", "-q", "-f", "json"])
+    cap = capsys.readouterr()
+    assert cap.err == ""
+    assert json.loads(cap.out)[0]["line"] == "あかねさす紫野ゆき"
+
+
+def test_cli_reports_missing_files_without_traceback(tmp_path, capsys):
+    lyrics = write_lyrics(tmp_path, "あかねさす紫野ゆき\n")
+    assert main([str(tmp_path / "nope.mp3"), str(lyrics)]) == 2
+    assert "audio file not found" in capsys.readouterr().err
+    assert main([str(lyrics), "--segments", str(tmp_path / "nope.json")]) == 2
+    assert "segments file not found" in capsys.readouterr().err
+
+
+def test_cli_rejects_empty_lyrics(tmp_path, capsys):
+    lyrics = write_lyrics(tmp_path, "[Verse 1]\n\n")
+    assert main([str(lyrics), "--segments", str(FIX)]) == 2
+    assert "no lyric lines" in capsys.readouterr().err


### PR DESCRIPTION
実データ end-to-end 実測で見つかった **public 化ブロッカー**を潰し、実測で判明した挙動をコード・ドキュメントに反映。

## README が謳っていたのに無かったもの

- **Demucs 分離が未実装だった** → `separate.py` を追加（キャッシュ付き・device 自動判定・`[separate]` extra 越し）し `--separate` に配線
- **`pip install lyric-align` は PyPI 未公開で失敗した** → `git+https` 手順に修正

## 実測で判明したこと（挙動と docs に反映）

| 入力 | matched | mean \|err\| |
|---|---|---|
| Demucs vocal stem | 19/20 | 0.50s |
| full mix | 8/20 | 1.59s |

- **mix 直入力は崩壊する**（4分曲で ASR セグメントが 41→11 に潰れ、1コーラス以降が全 unmatched）。`--separate` は「あると良い」ではなく実質必須
- **VAD がラップ用チューニングで、緩い歌唱を殺す**: 賛美歌で VAD ON = 130秒に 1 セグメント（ゴミ）／OFF = 12 セグメント（ほぼ完璧）。`--no-vad` を追加し、VAD で 0 セグメントなら**ログ付きで自動リトライ**
- **反復 Hook 行が別リピートに吸着する**: 4回反復行で +6.4/-3.8/-4.5/+5.7s の外れ値（他の行は ~0.5s 以内）。誤魔化さず Known limits に明記
- 2曲目（黒砂の誓い 3:03、GT 33行）で **33/33 matched・median 0.30s** を再現

## 「落ちた行を落ちたと言う」を実際に見えるようにした

- CLI が unmatched 行を**行番号＋similarity＋本文**で列挙（件数だけ出す実装だった＝pitch の核が不可視）
- 歌詞シートを貼り付けたまま使える（`[Verse 1]` 見出し・`# コメント`をスキップ）
- ファイル不在・optional extra 未導入は traceback でなく1行メッセージ + exit code
- PD 音源で1分で試せる例を追加（`examples/amazing_grace.txt` + Commons の curl 一発）

## テスト

11 → 18（CLI 挙動をカバー）。コアは同一 ASR 入力で監査時の 19/20・mean 0.50s をビット一致で再現＝抽出による退行なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)