### PR TITLE
docs: lead the install section with the CLI-tool path (uv tool / pipx)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,12 +17,26 @@ It is built for two things most aligners handle poorly:
 
 ## Install
 
-Not on PyPI yet — install from source:
+Not on PyPI yet — install from the repository.
+
+**As a command-line tool** (recommended — puts `lyric-align` on your PATH, in its
+own isolated environment):
 
 ```bash
-pip install "git+https://github.com/ijuinryukichi/lyric-align"           # core (pure stdlib)
-pip install "lyric-align[asr] @ git+https://github.com/ijuinryukichi/lyric-align"        # + faster-whisper (transcribe)
-pip install "lyric-align[asr,separate] @ git+https://github.com/ijuinryukichi/lyric-align"  # + demucs (vocal split)
+uv tool install "lyric-align[asr] @ git+https://github.com/ijuinryukichi/lyric-align"
+# or: pipx install "lyric-align[asr] @ git+https://github.com/ijuinryukichi/lyric-align"
+
+lyric-align --version
+```
+
+Add `separate` to the extras (`lyric-align[asr,separate]`) if you want Demucs
+vocal splitting; it pulls in torch, so leave it out until you need it.
+
+**As a library**, into your own environment:
+
+```bash
+pip install "git+https://github.com/ijuinryukichi/lyric-align"        # core only, pure stdlib
+pip install "lyric-align[asr] @ git+https://github.com/ijuinryukichi/lyric-align"
 ```
 
 ## Use


### PR DESCRIPTION
CLI ツールなのに install 手順が `pip install`（環境に入れる）だけで、結果ユーザーが `.venv/bin/lyric-align` を特定ディレクトリから叩く形になっていた。

- `uv tool install` / `pipx install` を推奨として先頭に置き、`lyric-align` が PATH に載る（隔離環境で）形を明示
- ライブラリ用途の pip 手順は下段に残す
- `separate` extra は torch を引くので「必要になるまで入れない」と注記

無関係な作業ディレクトリから end-to-end 検証済み: 130秒のトラックを transcribe + align して 36 秒、9/12 行アライン + 未マッチ 3 行を実名報告。

🤖 Generated with [Claude Code](https://claude.com/claude-code)