### PR TITLE
fix: script-aware match threshold, and name the cause of a poor match rate

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,11 +76,8 @@ lyric-align amazing_grace.mp3 examples/amazing_grace.txt \
 
 ```
 segments: 12
-aligned 9/12 lines
-unmatched (omitted from output) — check these lines:
-  line 10: sim 0.00  I have already come
-  line 11: sim 0.00  Tis grace hath brought me safe thus far
-  line 12: sim 0.00  And grace will lead me home
+match threshold: 0.5 (alphabetic script)
+aligned 12/12 lines
 ```
 
 ```
@@ -88,6 +85,9 @@ unmatched (omitted from output) — check these lines:
 [00:14.30]That saved a wretch like me
 [00:23.70]I once was lost, but now am found
 [00:34.52]Was blind, but now I see
+...
+[01:46.24]We've no less days to sing God's praise
+[01:57.46]Than when we first begun
 ```
 
 Note `--no-vad`: this is a slow hymn, and the ASR's voice-activity filter
@@ -95,6 +95,15 @@ mistakes sustained singing for silence. With the filter on, the same file yields
 **one** garbage segment for 130 seconds; with it off, twelve clean ones. Keep the
 filter for rap, drop it for anything sung slowly. (`--pairing 1` because this ASR
 already split one lyric line per segment.)
+
+Drop `--no-vad` and you can watch the honest-gap contract hold: every line is
+reported unmatched, nothing is written, and the cause is named.
+
+```
+only 0/12 lines matched from 1 segments — try --no-vad (the voice-activity
+filter silences slow singing), or --separate (a full mix hides the vocal
+from the ASR)
+```
 
 ### Feed it a vocal stem
 
@@ -167,6 +176,21 @@ A second track (3-minute Japanese rap, 33 human-marked lines, 1 s ground-truth
 granularity) reproduces this: **33/33 matched, median |err| 0.30 s**, 26/33
 within 0.5 s. Its mean of 0.94 s comes almost entirely from four outliers, all on
 the *same* line — see below.
+
+### Match threshold is script-aware
+
+A line is accepted when its character similarity clears a threshold, and the
+right floor depends on how many characters the language has to choose from. So
+the default is picked from the lyrics themselves (`--threshold` overrides it):
+
+| script | default | why |
+|---|---|---|
+| Japanese / Chinese | 0.25 | true matches against error-prone sung ASR drop as low as 0.26 |
+| alphabetic | 0.50 | two *unrelated* English sentences already score 0.28–0.34 |
+
+Using the CJK floor on English silently invents matches — measured on the hymn
+above, "Through many dangers, toils and snares" was placed on the line
+"We've no less days to sing God's praise" (similarity 0.34).
 
 ## Known limits
 

--- a/examples/amazing_grace.txt
+++ b/examples/amazing_grace.txt
@@ -8,7 +8,7 @@ And grace my fears relieved
 How precious did that grace appear
 The hour I first believed
 
-Through many dangers, toils and snares
-I have already come
-Tis grace hath brought me safe thus far
-And grace will lead me home
+When we've been there ten thousand years
+Bright shining as the sun
+We've no less days to sing God's praise
+Than when we first begun

--- a/src/lyric_align/cli.py
+++ b/src/lyric_align/cli.py
@@ -19,6 +19,7 @@ from . import __version__
 from .anchor import align, interpolate_gaps
 from .formats import FORMATTERS
 from .model import Segment
+from .normalize import CJK_THRESHOLD, LATIN_THRESHOLD, default_threshold
 
 SECTION_MARKER = re.compile(r"^[\[(](?:[^\[\]()]{0,40})[\])]$")
 
@@ -101,9 +102,11 @@ def build_parser() -> argparse.ArgumentParser:
     al.add_argument("--interpolate", action="store_true",
                     help="give unmatched lines guessed timestamps between their "
                          "neighbours (they stay flagged as unmatched)")
-    al.add_argument("--threshold", type=float, default=0.25,
-                    help="minimum character similarity to accept a match, 0-1 "
-                         "(default: %(default)s; raise it to reject dubious matches)")
+    al.add_argument("--threshold", type=float, default=None,
+                    help="minimum character similarity to accept a match, 0-1. Default "
+                         f"depends on the script of the lyrics: {CJK_THRESHOLD} for "
+                         f"Japanese/Chinese, {LATIN_THRESHOLD} for alphabetic scripts, "
+                         "where unrelated sentences score far higher by chance")
     al.add_argument("--window", type=int, default=4,
                     help="how many segments ahead to search for each line "
                          "(default: %(default)s; raise it if the ASR drops segments)")
@@ -168,8 +171,14 @@ def main(argv=None) -> int:
         print("error: provide AUDIO or --segments", file=sys.stderr)
         return 2
 
+    threshold = args.threshold
+    if threshold is None:
+        threshold = default_threshold(lyrics)
+        log(f"match threshold: {threshold} "
+            f"({'CJK' if threshold == CJK_THRESHOLD else 'alphabetic'} script)")
+
     aligned = align(segments, lyrics, pairing=args.pairing,
-                    threshold=args.threshold, window=args.window,
+                    threshold=threshold, window=args.window,
                     karaoke=args.karaoke)
     if args.interpolate:
         aligned = interpolate_gaps(aligned)
@@ -192,6 +201,19 @@ def main(argv=None) -> int:
         log(f"unmatched{filled} — check these lines:")
         for i, a in unmatched:
             log(f"  line {i}: sim {a.score:.2f}  {a.line}")
+
+    # A poor match rate almost always means the transcription was starved, not
+    # that the lyrics are wrong — say so, because the cause is not guessable
+    # from the output. (Only ASR runs can be diagnosed this way.)
+    if not args.segments and matched < len(aligned) * 0.6:
+        hints = []
+        if args.vad:
+            hints.append("--no-vad (the voice-activity filter silences slow singing)")
+        if not args.separate:
+            hints.append("--separate (a full mix hides the vocal from the ASR)")
+        if hints:
+            log(f"only {matched}/{len(aligned)} lines matched from {len(segments)} "
+                f"segments — try " + ", or ".join(hints))
 
     if args.output:
         Path(args.output).write_text(text)

--- a/src/lyric_align/normalize.py
+++ b/src/lyric_align/normalize.py
@@ -32,3 +32,38 @@ def similarity(a: str, b: str) -> float:
 def nchars(s: str) -> int:
     """Count of significant (non-space) characters."""
     return len(s.replace(' ', ''))
+
+
+# Hiragana, katakana, CJK ideographs (incl. extension A and compatibility) and
+# half-width katakana. Enough to tell "large character inventory" scripts apart
+# from alphabetic ones, which is all the threshold heuristic needs.
+_CJK = re.compile(r'[぀-ヿ㐀-䶿一-鿿豈-﫿ｦ-ﾟ]')
+
+CJK_THRESHOLD = 0.25
+LATIN_THRESHOLD = 0.50
+
+
+def cjk_ratio(text: str) -> float:
+    """Fraction of significant characters that are Japanese/Chinese."""
+    chars = normalize(text)
+    if not chars:
+        return 0.0
+    return len(_CJK.findall(chars)) / len(chars)
+
+
+def default_threshold(lyrics: list[str] | str) -> float:
+    """Pick a match threshold from the script the lyrics are written in.
+
+    A single similarity floor cannot serve both scripts, because chance
+    similarity depends on how many characters the language has to choose from.
+    Measured on real data:
+
+    - Japanese: unrelated lines score low, while *true* matches against error-prone
+      sung ASR drop as far as 0.26 — the floor has to stay low (0.25) or genuine
+      lines are discarded.
+    - Latin script: 26 letters plus shared vowels mean two completely unrelated
+      English sentences score 0.28-0.34, i.e. above that same floor. A 0.25
+      threshold silently invents matches; 0.50 leaves room above the noise.
+    """
+    text = "\n".join(lyrics) if not isinstance(lyrics, str) else lyrics
+    return CJK_THRESHOLD if cjk_ratio(text) >= 0.2 else LATIN_THRESHOLD

--- a/tests/test_normalize.py
+++ b/tests/test_normalize.py
@@ -1,4 +1,26 @@
-from lyric_align.normalize import nchars, normalize, similarity
+from lyric_align.normalize import (CJK_THRESHOLD, LATIN_THRESHOLD, cjk_ratio,
+                                   default_threshold, nchars, normalize, similarity)
+
+
+def test_default_threshold_is_script_aware():
+    assert default_threshold(["治部少輔に過ぎたるものが二つ在り"]) == CJK_THRESHOLD
+    assert default_threshold(["Amazing grace, how sweet the sound"]) == LATIN_THRESHOLD
+    # numerals and latin mixed into Japanese must not flip the script decision
+    assert default_threshold(["3.26 夜明け前 中将自ら 刀"]) == CJK_THRESHOLD
+
+
+def test_latin_default_rejects_chance_similarity():
+    # Two unrelated English lines score 0.34 — above the CJK floor, below the
+    # latin one. This is exactly the false match the split default prevents.
+    sim = similarity("Through many dangers, toils and snares",
+                     "We've no less days to sing God's praise")
+    assert CJK_THRESHOLD < sim < LATIN_THRESHOLD
+
+
+def test_cjk_ratio_extremes():
+    assert cjk_ratio("あいう漢字カタカナ") == 1.0
+    assert cjk_ratio("abc def") == 0.0
+    assert cjk_ratio("") == 0.0
 
 
 def test_normalize_strips_space_and_punct():


### PR DESCRIPTION
同梱 example を end-to-end で実行し、**ASR 生セグメントと出力を突き合わせて検証**したところ、デモが静かに間違っていた。

## 誤マッチ（invented timestamp）が出ていた

similarity の床 0.25 は日本語でチューニングした値。日本語は文字種が多いので無関係な行は低く出るが、**ラテン文字では偶然の一致が高く出る**（無関係な英文どうしで 0.28〜0.34）。結果、example で `Through many dangers, toils and snares` が `We've no less days to sing God's praise`（sim 0.34）に貼られていた。**このツールが「やらない」と謳っている挙動そのもの**。

床を一律に上げるのは不可: **日本語の真マッチは 0.26 まで下がる**（誤認識の多いトラックでは 0.28〜0.36 が普通）ので、上げると本物が落ちる。

→ **歌詞の文字種から既定値を決める**方式に変更。CJK 0.25 / alphabetic 0.50、毎回ログ出力、`--threshold` で上書き可。

| script | default | 根拠 |
|---|---|---|
| Japanese / Chinese | 0.25 | 誤認識ありの真マッチが 0.26 まで下がる |
| alphabetic | 0.50 | 無関係な英文どうしが既に 0.28〜0.34 |

## example の歌詞が間違っていた

録音の3節目は `Through many dangers` ではなく **`When we've been there ten thousand years`**。両方直して example は **12/12 マッチ、全タイムスタンプが ASR セグメント境界と一致**するようになった（修正前は 9/12 + 誤マッチ1件）。

## 低マッチ率の原因を名指しするようにした

VAD で ASR が枯れたケースは以前「1/12」と出るだけで原因が分からず詰んでいた（しかもその 1 が上記の誤マッチ）。現在:

```
only 0/12 lines matched from 1 segments — try --no-vad (the voice-activity filter
silences slow singing), or --separate (a full mix hides the vocal from the ASR)
```

嘘のタイムスタンプを出さず（0/12）、原因と次の手を提示する。

Tests: 18 → 21。

🤖 Generated with [Claude Code](https://claude.com/claude-code)