### PR TITLE
docs: record the measured failure of a global matcher for repeated hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,21 @@ above, "Through many dangers, toils and snares" was placed on the line
   above, one 4×-repeated hook line produced errors of +6.4 s, −3.8 s, −4.5 s and
   +5.7 s while every non-repeated line stayed within ~0.5 s. Check hook sections
   by hand, or align verses and hooks as separate passes.
+
+  Replacing the forward scan with a globally optimal monotone assignment does
+  *not* fix this, and measured worse. Identical repetitions carry identical
+  similarity, so the global optimum just places more lines — and the extra ones
+  land on the wrong cycle:
+
+  | matcher | lines placed | mean \|err\| | within 0.5 s | worst |
+  |---|---|---|---|---|
+  | forward scan (shipped) | 70/80 | **0.94 s** | **26/33** | **6.4 s** |
+  | global optimum | 80/80 | 1.61 s | 22/33 | 10.6 s |
+  | global optimum + diagonal-drift penalty | 80/80 | 1.14 s | 25/33 | 10.6 s |
+
+  Telling repetitions apart needs a timing prior, not a better search over
+  similarity. Meanwhile the forward window is doing real work: it stops a line
+  from reaching a distant segment that happens to clear the threshold.
 - **Slow, sustained singing is much harder than rap** — hymns, ballads and
   school songs stretch vowels until the ASR stops producing usable segments.
   Reach for `--no-vad` first (see the one-minute example); dense, consonant-rich

--- a/src/lyric_align/anchor.py
+++ b/src/lyric_align/anchor.py
@@ -5,17 +5,27 @@ source) and ASR segments with word timings, we place each lyric line/stanza on
 the timeline by character-level fuzzy matching, moving forward monotonically so
 repeated lines (choruses) consume segments in order.
 
+The forward `window` is load-bearing, not just an optimisation: it keeps a line
+from reaching a distant segment that happens to clear the threshold. Replacing
+this scan with a globally optimal monotone assignment (maximise total similarity,
+optionally minus a diagonal-drift penalty) was tried and measured worse — it
+places every line, but repeated hooks carry no distinguishing similarity, so the
+extra placements land on the wrong repetition: mean error 0.94 s -> 1.14-1.61 s,
+worst 6.4 s -> 10.6 s on a track with a 4x-repeated hook. Locality beats global
+optimality here because similarity alone cannot tell repetitions apart.
+
 Design philosophy: when a line cannot be confidently matched, we mark it
 unmatched rather than inventing a timestamp. Forced aligners always emit an
 answer and thus fail *silently* (e.g. drifting into the intro); we prefer honest
-gaps that a human — or a later interpolation pass — can fix.
+gaps that a human — or a later interpolation pass — can fix. The same reasoning
+rejects the global matcher above: a visible gap beats a confident wrong time.
 """
 from __future__ import annotations
 
 from .breath import split_words_by_breath
 from .charmap import char_timings
 from .model import AlignedLine, Segment
-from .normalize import similarity
+from .normalize import default_threshold, similarity
 
 
 def _stanzas(lines: list[str], pairing: int) -> list[list[str]]:
@@ -30,7 +40,7 @@ def align(
     lyrics: list[str],
     *,
     pairing: int = 2,
-    threshold: float = 0.25,
+    threshold: float | None = None,
     window: int = 4,
     karaoke: bool = False,
 ) -> list[AlignedLine]:
@@ -40,13 +50,17 @@ def align(
         pairing: lyric lines per stanza unit matched to one segment. Whisper
             merges ~2 sung lines per segment, so 2 is a good default for
             Japanese rap; use 1 if your ASR already splits per line.
-        threshold: minimum character similarity to accept a match.
+        threshold: minimum character similarity to accept a match. Defaults to a
+            script-aware value (see `normalize.default_threshold`).
         window: how many segments ahead to search from the current position.
         karaoke: if True, compute per-character timings (needs word timings).
 
     Returns one AlignedLine per input lyric line (stanzas are expanded back to
     lines via breath splitting).
     """
+    if threshold is None:
+        threshold = default_threshold(lyrics)
+
     units = _stanzas(lyrics, pairing)
     results: list[AlignedLine] = []
     idx = 0


### PR DESCRIPTION
反復 Hook の弱点を狙って **貪欲 forward scan → DP 全体最適**（units × segments で類似度総和最大化・単調制約）に置換したが、**GT 2曲の実測で悪化したため不採用**。結果を捨てずに記録する。

| matcher | lines placed | mean \|err\| | within 0.5s | worst |
|---|---|---|---|---|
| forward scan（現行・維持） | 70/80 | **0.94s** | **26/33** | **6.4s** |
| global optimum | 80/80 | 1.61s | 22/33 | 10.6s |
| global optimum + diagonal-drift penalty | 80/80 | 1.14s | 25/33 | 10.6s |

（過ぎたるものは 19/20・mean 0.50s で退行なし。差が出るのは 4回反復 Hook を持つ黒砂）

## なぜこの定式化では解けないか

反復 Hook は**同一文字列**なので similarity に「どの周か」の情報がゼロ。かつ「置く（+sim）」が「落とす（0）」より常に得なので、**全体最適は全行を埋め、余った行が1周ズレた位置に着地**する。

- **一律スキップ料は無効**: マッチ数が決まればスキップ数も決まるので定数項になり、「どこを飛ばすか」の選好を作れない
- **対角プライア**（|i/m − j/n| ペナルティ）は多少効くが scan に届かない

反復の判別には **timing prior** が必要で、これは別規模の作業。

## 副産物の知見

forward `window` は最適化ではなく**本質的な制約**だった。遠方の「閾値を超えてしまう」セグメントに手が届かないことが偽マッチを防いでいて、DP ではまさにその偽マッチが鎖全体を1セグメントずらしていた。honest-gap の主張とも整合する（見える欠落 > 自信ありげな誤答）。

`align()` が `threshold=None` を受けて script-aware 既定を導出するようにし、ライブラリと CLI の挙動を揃えた。

21 tests pass。

🤖 Generated with [Claude Code](https://claude.com/claude-code)