### PR TITLE
feat: eLRC, WebVTT, TTML and Audacity labels; -f all (v0.3.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,51 @@ works as-is. `segments.json` is a list of
 `{"start", "end", "text", "words": [{"start","end","word"}]}` — the shape any
 Whisper flavor produces.
 
+## Output: pick the format your next tool eats
+
+`-f all -o out` writes every format at once.
+
+| format | what it is | where it goes next |
+|---|---|---|
+| `lrc` | line-timed lyrics | music players; contributing to [LRCLIB](https://lrclib.net) |
+| `elrc` | LRC A2 — same file, inline per-syllable timestamps | word-by-word players (AIMP, QQ/NetEase/Kugou, Chronograph), karaoke editors |
+| `srt` | universal subtitles | `ffmpeg`, video editors, YouTube captions |
+| `vtt` | WebVTT | HTML5 `<track>`, web players |
+| `ass` | styling + `\k` karaoke sweeps | Aegisub, `ffmpeg` burn-in |
+| `ttml` | per-syllable rich lyrics | Apple-style / AMLL-ecosystem players |
+| `aud` | Audacity label track (`start⇥end⇥text`) | **fixing the timings by hand**; also plain TSV |
+| `json` | everything, including scores and unmatched lines | your own code |
+
+Per-syllable formats split by script: alphabetic text is grouped into words
+(`<00:06.60>Amazing <00:08.82>grace`), CJK stays one unit per character
+(`<00:21.78>治<00:21.94>部`), which is how per-character karaoke formats treat
+Japanese and Chinese.
+
+`lrc`/`elrc` cannot express an end time — the last syllable of a line has no
+close. Every other format carries the end times this aligner computes.
+
+### Recipes
+
+```bash
+# burn subtitles into a video
+ffmpeg -i video.mp4 -vf "ass=out.ass" -c:a copy out.mp4
+
+# karaoke sweep instead of plain lines
+lyric-align song.wav lyrics.txt -f ass --karaoke -o out.ass
+
+# fix a mistimed line by hand: import out.labels.txt into Audacity
+#   (File > Import > Labels), drag it over the waveform, export the labels again
+lyric-align song.wav lyrics.txt -f aud -o out.labels.txt
+
+# web player
+lyric-align song.wav lyrics.txt -f vtt -o out.vtt
+```
+
+Formats deliberately left out: UltraStar `.txt` and CDG need sung **pitch**, not
+just timing — [UltraSinger](https://github.com/rakuri255/UltraSinger) and
+[karaoke-gen](https://github.com/nomadkaraoke/karaoke-gen) cover that. Apple
+Music and Spotify do not accept user-supplied lyric files at all.
+
 ### Try it in one minute
 
 Both the recording and the lyrics below are public domain, so this runs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "lyric-align"
-version = "0.2.0"
+version = "0.3.0"
 description = "Place known lyrics on an audio timeline — CJK-first, built for sung vocals and rap."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/lyric_align/__init__.py
+++ b/src/lyric_align/__init__.py
@@ -9,7 +9,7 @@ from .anchor import align, interpolate_gaps
 from .model import AlignedLine, Segment, Word
 from .normalize import normalize, similarity
 
-__version__ = "0.2.0"
+__version__ = "0.3.0"
 
 __all__ = [
     "align", "interpolate_gaps",

--- a/src/lyric_align/charmap.py
+++ b/src/lyric_align/charmap.py
@@ -8,7 +8,7 @@ the (possibly misspelled) ASR words.
 from __future__ import annotations
 
 from .model import Word
-from .normalize import nchars
+from .normalize import cjk_ratio, nchars
 
 
 def char_timings(text: str, words: list[Word]) -> list[dict]:
@@ -37,4 +37,50 @@ def char_timings(text: str, words: list[Word]) -> list[dict]:
         out.append({"char": ch, "start": round(t_at(j), 3),
                     "end": round(t_at(j + 1), 3)})
         j += 1
+    return out
+
+
+def syllable_timings(text: str, chars: list[dict]) -> list[dict]:
+    """Group per-character timings into the units a karaoke format highlights.
+
+    Returns [{"text", "start", "end"}]. The grouping differs by script, because
+    what counts as a "syllable" to highlight does:
+
+    - Alphabetic text is grouped on whitespace, so "Amazing grace" highlights two
+      words rather than twelve letters.
+    - CJK text keeps one unit per character, which is how per-character karaoke
+      formats (QQ/NetEase style) treat Chinese and Japanese. Japanese lyrics often
+      contain spaces as phrasing, so splitting on them would give useless chunks.
+    """
+    if not chars:
+        return []
+    if cjk_ratio(text) >= 0.2:
+        return [{"text": c["char"], "start": c["start"], "end": c["end"]} for c in chars]
+
+    units: list[dict] = []
+    it = iter(chars)
+    current: list[dict] = []
+    for ch in text:
+        if ch.isspace():
+            if current:
+                units.append(current)
+                current = []
+            continue
+        try:
+            current.append(next(it))
+        except StopIteration:
+            break
+    if current:
+        units.append(current)
+
+    out = []
+    pos = 0
+    for group in units:
+        # Recover the original spelling: the char timings hold only the
+        # characters, so slice the source text by the same non-space run.
+        while pos < len(text) and text[pos].isspace():
+            pos += 1
+        word = text[pos:pos + len(group)]
+        pos += len(group)
+        out.append({"text": word, "start": group[0]["start"], "end": group[-1]["end"]})
     return out

--- a/src/lyric_align/cli.py
+++ b/src/lyric_align/cli.py
@@ -17,7 +17,7 @@ from pathlib import Path
 
 from . import __version__
 from .anchor import align, interpolate_gaps
-from .formats import FORMATTERS
+from .formats import EXTENSIONS, FORMATTERS, NEEDS_SYLLABLES
 from .model import Segment
 from .normalize import CJK_THRESHOLD, LATIN_THRESHOLD, default_threshold
 
@@ -70,10 +70,13 @@ def build_parser() -> argparse.ArgumentParser:
 
     out = p.add_argument_group("output")
     out.add_argument("-o", "--output", help="output path (default: stdout)")
-    out.add_argument("-f", "--format", default=None, choices=sorted(FORMATTERS),
-                     help="output format (default: infer from -o, else json)")
+    out.add_argument("-f", "--format", default=None,
+                     choices=sorted(FORMATTERS) + ["all"],
+                     help="output format (default: infer from -o, else json). "
+                          "'all' writes every format next to -o")
     out.add_argument("--karaoke", action="store_true",
-                     help="per-character timings, for karaoke \\k tags (ass/json)")
+                     help="per-character timings, for karaoke \\k tags (ass/json). "
+                          "Always on for elrc/ttml, which are per-syllable formats")
     out.add_argument("-q", "--quiet", action="store_true", help="suppress progress reporting")
 
     asr = p.add_argument_group(
@@ -171,6 +174,21 @@ def main(argv=None) -> int:
         print("error: provide AUDIO or --segments", file=sys.stderr)
         return 2
 
+    fmt = args.format
+    if fmt is None and args.output:
+        fmt = Path(args.output).suffix.lstrip(".").lower()
+    if fmt != "all" and fmt not in FORMATTERS:
+        fmt = "json"
+
+    if fmt == "all" and not args.output:
+        print("error: -f all needs -o to name the files to write", file=sys.stderr)
+        return 2
+
+    targets = sorted(FORMATTERS) if fmt == "all" else [fmt]
+    # Per-syllable formats are pointless without character timings, so turn them
+    # on for those rather than silently emitting line-level output.
+    karaoke = args.karaoke or bool(NEEDS_SYLLABLES.intersection(targets))
+
     threshold = args.threshold
     if threshold is None:
         threshold = default_threshold(lyrics)
@@ -179,16 +197,9 @@ def main(argv=None) -> int:
 
     aligned = align(segments, lyrics, pairing=args.pairing,
                     threshold=threshold, window=args.window,
-                    karaoke=args.karaoke)
+                    karaoke=karaoke)
     if args.interpolate:
         aligned = interpolate_gaps(aligned)
-
-    fmt = args.format
-    if fmt is None and args.output:
-        fmt = Path(args.output).suffix.lstrip(".").lower()
-    if fmt not in FORMATTERS:
-        fmt = "json"
-    text = FORMATTERS[fmt](aligned, karaoke=args.karaoke)
 
     matched = sum(1 for a in aligned if a.matched)
     log(f"aligned {matched}/{len(aligned)} lines")
@@ -215,11 +226,18 @@ def main(argv=None) -> int:
             log(f"only {matched}/{len(aligned)} lines matched from {len(segments)} "
                 f"segments — try " + ", or ".join(hints))
 
-    if args.output:
-        Path(args.output).write_text(text)
+    if fmt == "all":
+        base = Path(args.output)
+        base = base.with_name(base.name[:-len(base.suffix)] if base.suffix else base.name)
+        for name in targets:
+            path = base.with_name(base.name + EXTENSIONS[name])
+            path.write_text(FORMATTERS[name](aligned, karaoke=karaoke))
+            log(f"wrote {path}")
+    elif args.output:
+        Path(args.output).write_text(FORMATTERS[fmt](aligned, karaoke=karaoke))
         log(f"wrote {args.output}")
     else:
-        sys.stdout.write(text)
+        sys.stdout.write(FORMATTERS[fmt](aligned, karaoke=karaoke))
     return 0
 
 

--- a/src/lyric_align/formats.py
+++ b/src/lyric_align/formats.py
@@ -1,8 +1,27 @@
-"""Output formatters: JSON, LRC, SRT, and karaoke ASS."""
+"""Output formatters.
+
+Each format exists because some downstream tool eats it:
+
+- ``lrc``  — the de-facto lyrics format; music players and the LRCLIB database.
+- ``elrc`` — LRC A2 / Enhanced LRC, the same file with inline per-word timestamps;
+  word-level players (AIMP, QQ/NetEase/Kugou, Chronograph) and karaoke editors.
+- ``srt``  — universal subtitles: ffmpeg, video editors, YouTube captions.
+- ``vtt``  — WebVTT, for HTML5 ``<track>`` and web players.
+- ``ass``  — full styling plus ``\\k`` karaoke sweeps; Aegisub and ffmpeg burn-in.
+- ``ttml`` — word-level rich lyrics (Apple-style / AMLL ecosystem).
+- ``aud``  — Audacity label track, i.e. the *correction* loop: import over the
+  waveform, drag the wrong lines, export. Doubles as a generic TSV.
+- ``json`` — everything, including similarity scores and unmatched lines.
+
+LRC and eLRC cannot express an end time; SRT/VTT/ASS/TTML/AUD/JSON all carry the
+ones this aligner computes.
+"""
 from __future__ import annotations
 
 import json
+from xml.sax.saxutils import escape
 
+from .charmap import syllable_timings
 from .model import AlignedLine
 
 
@@ -29,6 +48,32 @@ def to_lrc(aligned: list[AlignedLine]) -> str:
     return "\n".join(lines) + "\n"
 
 
+def to_elrc(aligned: list[AlignedLine]) -> str:
+    """LRC A2 (Enhanced LRC): line timestamp plus inline per-syllable timestamps.
+
+    Falls back to the bare line when per-character timings are absent, which keeps
+    the file valid plain LRC rather than emitting something half-timed.
+    """
+    lines = []
+    for a in aligned:
+        if _skip(a):
+            continue
+        units = syllable_timings(a.line, a.chars or [])
+        if not units:
+            lines.append(f"{_lrc_ts(a.start)}{a.line}")
+            continue
+        body = "".join(f"<{_lrc_ts(u['start'])[1:-1]}>{u['text']}"
+                       + (" " if _spaced(a.line) and i < len(units) - 1 else "")
+                       for i, u in enumerate(units))
+        lines.append(f"{_lrc_ts(a.start)}{body}")
+    return "\n".join(lines) + "\n"
+
+
+def _spaced(line: str) -> bool:
+    """Whether syllable units should be re-joined with spaces (alphabetic text)."""
+    return " " in line.strip()
+
+
 def _srt_ts(t: float) -> str:
     h = int(t // 3600)
     m = int(t % 3600 // 60)
@@ -49,6 +94,81 @@ def to_srt(aligned: list[AlignedLine]) -> str:
         out.append("")
         n += 1
     return "\n".join(out)
+
+
+def to_vtt(aligned: list[AlignedLine]) -> str:
+    """WebVTT — same cues as SRT with dotted milliseconds, for HTML5 <track>."""
+    out = ["WEBVTT", ""]
+    n = 1
+    for a in aligned:
+        if _skip(a):
+            continue
+        out.append(str(n))
+        out.append(f"{_srt_ts(a.start).replace(',', '.')} --> "
+                   f"{_srt_ts(a.end).replace(',', '.')}")
+        out.append(a.line)
+        out.append("")
+        n += 1
+    return "\n".join(out)
+
+
+def to_aud(aligned: list[AlignedLine]) -> str:
+    """Audacity label track: start<TAB>end<TAB>text.
+
+    The point of this format is the round trip. Audacity's File > Import > Labels
+    puts every line on the waveform, where a wrong hook placement is obvious and
+    can be dragged into place, then exported again. Also readable as plain TSV.
+    """
+    rows = []
+    for a in aligned:
+        if _skip(a):
+            continue
+        rows.append(f"{a.start:.6f}\t{a.end:.6f}\t{a.line}")
+    return "\n".join(rows) + "\n"
+
+
+def _ttml_ts(t: float) -> str:
+    h = int(t // 3600)
+    m = int(t % 3600 // 60)
+    s = t % 60
+    return f"{h:02d}:{m:02d}:{s:06.3f}"
+
+
+def to_ttml(aligned: list[AlignedLine], lang: str = "") -> str:
+    """TTML with per-syllable spans — the shape Apple-style rich lyrics use.
+
+    Word timings become nested <span> elements inside the line <p>, which is what
+    players in that ecosystem (e.g. AMLL) read for word-by-word highlighting.
+    """
+    body = []
+    for i, a in enumerate(aligned, 1):
+        if _skip(a):
+            continue
+        units = syllable_timings(a.line, a.chars or [])
+        p_open = (f'      <p begin="{_ttml_ts(a.start)}" end="{_ttml_ts(a.end)}" '
+                  f'itunes:key="L{i}">')
+        if units:
+            joiner = " " if _spaced(a.line) else ""
+            inner = joiner.join(
+                f'<span begin="{_ttml_ts(u["start"])}" end="{_ttml_ts(u["end"])}">'
+                f'{escape(u["text"])}</span>' for u in units)
+        else:
+            inner = escape(a.line)
+        body.append(f"{p_open}{inner}</p>")
+    lang_attr = f' xml:lang="{escape(lang)}"' if lang else ""
+    return (
+        '<?xml version="1.0" encoding="UTF-8"?>\n'
+        '<tt xmlns="http://www.w3.org/ns/ttml"\n'
+        '    xmlns:ttm="http://www.w3.org/ns/ttml#metadata"\n'
+        '    xmlns:itunes="http://music.apple.com/lyric-ttml-internal"'
+        f'{lang_attr}>\n'
+        '  <body>\n'
+        '    <div>\n'
+        + "\n".join(body) + "\n"
+        '    </div>\n'
+        '  </body>\n'
+        '</tt>\n'
+    )
 
 
 def _ass_ts(t: float) -> str:
@@ -95,6 +215,21 @@ def to_ass(aligned: list[AlignedLine], karaoke: bool = False) -> str:
 FORMATTERS = {
     "json": lambda a, karaoke=False: to_json(a),
     "lrc": lambda a, karaoke=False: to_lrc(a),
+    "elrc": lambda a, karaoke=False: to_elrc(a),
     "srt": lambda a, karaoke=False: to_srt(a),
+    "vtt": lambda a, karaoke=False: to_vtt(a),
     "ass": lambda a, karaoke=False: to_ass(a, karaoke=karaoke),
+    "ttml": lambda a, karaoke=False: to_ttml(a),
+    "aud": lambda a, karaoke=False: to_aud(a),
+}
+
+# Formats whose whole point is per-syllable timing, so the CLI computes character
+# timings for them even without --karaoke.
+NEEDS_SYLLABLES = frozenset({"elrc", "ttml"})
+
+# Filename suffix per format when writing several at once (-f all). Audacity's
+# label importer filters for .txt, so that is what the label track gets.
+EXTENSIONS = {
+    "json": ".json", "lrc": ".lrc", "elrc": ".elrc", "srt": ".srt",
+    "vtt": ".vtt", "ass": ".ass", "ttml": ".ttml", "aud": ".labels.txt",
 }

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -1,0 +1,108 @@
+import json
+import re
+
+from lyric_align.charmap import char_timings, syllable_timings
+from lyric_align.formats import (EXTENSIONS, FORMATTERS, to_aud, to_elrc, to_ttml,
+                                 to_vtt)
+from lyric_align.model import AlignedLine, Word
+
+WORDS_EN = [Word(0.0, 0.5, "Amazing"), Word(0.5, 1.0, "grace")]
+WORDS_JA = [Word(0.0, 0.5, "島の"), Word(0.5, 1.0, "左近")]
+
+
+def en_line():
+    line = "Amazing grace"
+    return AlignedLine(line, 0.0, 1.0, 0.9, True, char_timings(line, WORDS_EN))
+
+
+def ja_line():
+    line = "島の左近"
+    return AlignedLine(line, 0.0, 1.0, 0.9, True, char_timings(line, WORDS_JA))
+
+
+def test_syllables_group_on_space_for_latin():
+    units = syllable_timings("Amazing grace", char_timings("Amazing grace", WORDS_EN))
+    assert [u["text"] for u in units] == ["Amazing", "grace"]
+    assert units[0]["start"] == 0.0
+
+
+def test_syllables_stay_per_character_for_cjk():
+    # Japanese lyrics use spaces as phrasing, so splitting on them would give
+    # useless chunks; per-character is what CJK karaoke formats expect.
+    line = "硫黄が満ちる 道の奥"
+    units = syllable_timings(line, char_timings(line, WORDS_JA))
+    assert [u["text"] for u in units] == list("硫黄が満ちる道の奥")
+
+
+def test_elrc_has_line_and_inline_timestamps():
+    out = to_elrc([en_line()])
+    assert out.startswith("[00:00.00]")
+    assert "<00:00.00>Amazing" in out
+    assert re.search(r"<\d\d:\d\d\.\d\d>grace", out)
+
+
+def test_elrc_falls_back_to_plain_line_without_char_timings():
+    out = to_elrc([AlignedLine("Amazing grace", 0.0, 1.0, 0.9, True, None)])
+    assert out.strip() == "[00:00.00]Amazing grace"
+
+
+def test_vtt_header_and_dotted_milliseconds():
+    out = to_vtt([en_line()])
+    assert out.startswith("WEBVTT")
+    assert "00:00:00.000 --> 00:00:01.000" in out
+
+
+def test_aud_is_tab_separated_start_end_text():
+    row = to_aud([en_line()]).strip().split("\t")
+    assert row == ["0.000000", "1.000000", "Amazing grace"]
+
+
+def test_ttml_wraps_syllables_in_spans_and_escapes():
+    line = AlignedLine("rock & roll", 0.0, 1.0, 0.9, True,
+                       char_timings("rock & roll", WORDS_EN))
+    out = to_ttml([line])
+    assert '<tt xmlns="http://www.w3.org/ns/ttml"' in out
+    assert 'begin="00:00:00.000" end="00:00:01.000"' in out
+    assert "&amp;" in out and "&" in out
+    assert out.count("<span") >= 2
+
+
+def test_unmatched_lines_are_absent_from_every_text_format():
+    lines = [en_line(), AlignedLine("dropped line", None, None, 0.1, False, None)]
+    for name, fmt in FORMATTERS.items():
+        out = fmt(lines, karaoke=True)
+        if name == "json":
+            assert any(d["line"] == "dropped line" for d in json.loads(out))
+        else:
+            assert "dropped line" not in out
+
+
+def test_every_format_has_an_extension():
+    assert set(EXTENSIONS) == set(FORMATTERS)
+
+
+def test_cli_writes_every_format_with_f_all(tmp_path, capsys):
+    from lyric_align.cli import main
+    from pathlib import Path
+    fix = Path(__file__).parent / "fixtures" / "segments_sample.json"
+    lyrics = tmp_path / "l.txt"
+    lyrics.write_text("あかねさす紫野ゆき\n標野ゆき野守は見ずや\n君が袖振る\n")
+    rc = main([str(lyrics), "--segments", str(fix), "--pairing", "1",
+               "-f", "all", "-o", str(tmp_path / "out")])
+    assert rc == 0
+    for ext in EXTENSIONS.values():
+        assert (tmp_path / f"out{ext}").exists(), ext
+    # elrc/ttml are per-syllable formats: they must get char timings even though
+    # --karaoke was not passed.
+    assert "<00:00.50>" in (tmp_path / "out.elrc").read_text()
+    capsys.readouterr()
+
+
+def test_cli_rejects_f_all_without_output(tmp_path, capsys):
+    from lyric_align.cli import main
+    from pathlib import Path
+    fix = Path(__file__).parent / "fixtures" / "segments_sample.json"
+    lyrics = tmp_path / "l.txt"
+    lyrics.write_text("あかねさす紫野ゆき\n")
+    assert main([str(lyrics), "--segments", str(fix), "-f", "all"]) == 2
+    assert "needs -o" in capsys.readouterr().err


### PR DESCRIPTION
既存4形式（json/lrc/srt/ass）は **行レベル字幕の形**で、「時刻↔歌詞マップを食えるパイプラインを既に持っている人」を前提にしていた。同種 OSS の出力と、実際に歌詞を取り込む先を調査した結果、**ワークフローを持たない一般ユーザーに対して穴が3つ**あった。

## 調査で分かった前提

| ツール | 出力 |
|---|---|
| aeneas | AUD / CSV / EAF / JSON / SMIL / SRT / SSV / SUB / TEXTGRID / TSV / TTML / TXT / VTT / XML |
| stable-ts | SRT / VTT / ASS / TSV / JSON（行＋語） |
| WhisperX | SRT / VTT / TXT / TSV / JSON |
| karaoke-gen / lyrics-transcriber | LRC・MidiCo LRC / ASS / CDG / MP4 |

歌詞生態系の出口: **LRC**（事実上の標準、LRCLIB≒300万曲が FOSS プレイヤーのハブ）/ **eLRC (LRC A2)**（語レベル、AIMP・QQ・NetEase・Kugou・Chronograph）/ **TTML**（AMLL 主形式、語レベル＋翻訳・ルビ）。**Apple Music / Spotify はユーザー提供ファイルを受け付けない**。

## 埋めた穴

1. **語レベルの出口が ASS だけだった** → `elrc` 追加。文字タイミングは既に計算していたので「出せるのに出していない」状態だった
2. **WebVTT が無かった** → `vtt` 追加（HTML5 `<track>`・Web プレイヤー）
3. **間違いを直す導線が無かった** → `aud`（Audacity ラベル）追加。反復 Hook は「人間が直す」前提の既知弱点なのに、直す手段が無かった。波形の上に全行が乗り、ズレをドラッグして書き出せる（aeneas が AUD を持つのと同じ理由）

加えて `ttml`（音節 span、Apple/AMLL 形）と **`-f all`**（aeneas/WhisperX 流儀、-o の隣に全形式）。`elrc`/`ttml` は `--karaoke` 無しでも文字タイミングを自動有効化する（行レベルで出したら形式の意味が無い）。

## 音節グルーピングは script-aware

閾値と同じ判定を再利用: ラテン文字は空白で語に、**CJK は文字単位**（日本語歌詞は空白を「間」として使うので空白分割は無意味、かつ文字単位が CJK カラオケ形式の作法）。

```
[00:06.60]<00:06.60>Amazing <00:08.82>grace, <00:10.36>how
[00:21.78]<00:21.78>治<00:21.94>部<00:22.09>少<00:22.25>輔
```

## README

全形式 → 後続ツールの対応表、レシピ（ffmpeg 焼き込み / Aegisub / Audacity 修正ループ / LRCLIB）、**lrc/elrc は終了時刻を持てない**旨、意図的に対象外とした形式（UltraStar・CDG は音高が必要 → UltraSinger/karaoke-gen の領域）。

Tests: 21 → 32。

🤖 Generated with [Claude Code](https://claude.com/claude-code)