### PR TITLE
fix: keep syllable timings strictly positive and non-overlapping

### DIFF
--- a/src/lyric_align/charmap.py
+++ b/src/lyric_align/charmap.py
@@ -11,10 +11,18 @@ from .model import Word
 from .normalize import cjk_ratio, nchars
 
 
+MIN_CHAR_DUR = 0.01
+
+
 def char_timings(text: str, words: list[Word]) -> list[dict]:
     """Return [{"char", "start", "end"}] for each non-space character in text.
 
     Spaces are skipped (no karaoke syllable). If `words` is empty, returns [].
+
+    Durations are kept strictly positive and non-overlapping: proportional
+    interpolation plus rounding to milliseconds can otherwise collapse a
+    character to zero length, which downstream means a `\\k0` sweep or a TTML span
+    with begin == end.
     """
     if not words:
         return []
@@ -29,14 +37,30 @@ def char_timings(text: str, words: list[Word]) -> list[dict]:
         i = min(int(pos), n - 1)
         return bounds[i] + (bounds[i + 1] - bounds[i]) * (pos - i)
 
+    # A very short span cannot give every character MIN_CHAR_DUR; share it out.
+    span = max(bounds[-1] - bounds[0], 0.0)
+    min_dur = min(MIN_CHAR_DUR, span / m) if m else 0.0
+
     out = []
     j = 0
+    prev_end = bounds[0]
     for ch in text:
         if ch == ' ':
             continue
-        out.append({"char": ch, "start": round(t_at(j), 3),
-                    "end": round(t_at(j + 1), 3)})
+        start = max(t_at(j), prev_end)
+        end = max(t_at(j + 1), start + min_dur)
+        out.append({"char": ch, "start": round(start, 3), "end": round(end, 3)})
+        prev_end = end
         j += 1
+
+    # Rounding can re-introduce a collision at millisecond resolution.
+    for a, b in zip(out, out[1:]):
+        if b["start"] < a["end"]:
+            b["start"] = a["end"]
+        if b["end"] <= b["start"]:
+            b["end"] = round(b["start"] + MIN_CHAR_DUR, 3)
+    if out and out[0]["end"] <= out[0]["start"]:
+        out[0]["end"] = round(out[0]["start"] + MIN_CHAR_DUR, 3)
     return out
 
 

--- a/tests/test_anchor.py
+++ b/tests/test_anchor.py
@@ -62,3 +62,12 @@ def test_char_timings_skips_spaces():
     words = [Word(0.0, 1.0, "ab"), Word(1.0, 2.0, "cd")]
     ct = char_timings("a b", words)
     assert [c["char"] for c in ct] == ["a", "b"]
+
+
+def test_char_timings_are_strictly_positive_and_ordered():
+    # Many characters over a short span is where proportional interpolation plus
+    # millisecond rounding used to collapse a syllable to zero length.
+    words = [Word(10.0, 10.06, "ab"), Word(10.06, 10.12, "cd")]
+    ct = char_timings("島の左近と佐和山の城なり", words)
+    assert all(c["end"] > c["start"] for c in ct)
+    assert all(b["start"] >= a["end"] for a, b in zip(ct, ct[1:]))


### PR DESCRIPTION
実出力のバイトを検査して発見: 過ぎたるもの 1 曲の eLRC で **712 音節中 3 個が `end <= start`**（同一タイムスタンプ連続 = ゼロ長音節）。

```
<00:23.30>左<00:23.30>と      ← 0ms
```

文字比例マップの補間 + ミリ秒丸めで潰れるケース。下流では **ASS の `\k0` スイープ**、**TTML の `begin == end` span** という退化した指定になり、プレイヤー実装次第で挙動が不安定になる。eLRC / TTML / karaoke ASS は今回の主役機能なので修正。

対処: 文字タイミングを構築する際に前の文字の終端以降へクランプし、最小長 `MIN_CHAR_DUR = 0.01s` を保証。span が短くて全文字に 10ms 配れない場合は `span / 文字数` に縮退させる（overshoot しない）。丸めで再衝突する分は後段パスで解消。

実測: 同一入力で 3 → **0 件**（712 音節すべて厳密単調増加）。

Tests: 32 → 33。

🤖 Generated with [Claude Code](https://claude.com/claude-code)