### PR TITLE
fix: make TTML survive a real parse, in both scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,10 +79,22 @@ Whisper flavor produces.
 Per-syllable formats split by script: alphabetic text is grouped into words
 (`<00:06.60>Amazing <00:08.82>grace`), CJK stays one unit per character
 (`<00:21.78>治<00:21.94>部`), which is how per-character karaoke formats treat
-Japanese and Chinese.
+Japanese and Chinese. The separator between units is taken from the source line
+rather than inferred, so a Japanese line that carries a phrasing space
+(`硫黄が満ちる 道の奥`) rebuilds character-for-character instead of gaining a
+space between every character.
 
 `lrc`/`elrc` cannot express an end time — the last syllable of a line has no
 close. Every other format carries the end times this aligner computes.
+
+The `ttml` output is checked against the AMLL reference parser
+([`@applemusic-like-lyrics/ttml`](https://github.com/amll-dev/applemusic-like-lyrics)),
+not just against the XML schema: lines, per-unit text and millisecond timings
+survive a real parse unchanged, in both scripts. It declares a single
+`ttm:agent` because the spec wants one per line, and carries `xml:lang` from
+`--language`. The title/artist/album an AMLL *database submission* also wants
+are deliberately absent — this tool is handed audio and lyrics and nothing else,
+so it does not invent them.
 
 ### Recipes
 

--- a/src/lyric_align/anchor.py
+++ b/src/lyric_align/anchor.py
@@ -35,6 +35,23 @@ def _stanzas(lines: list[str], pairing: int) -> list[list[str]]:
     return [lines[i:i + pairing] for i in range(0, len(lines), pairing)]
 
 
+def _containing(start: float, end: float, chars: list[dict] | None) -> tuple[float, float]:
+    """Widen a line span so it contains its own character timings.
+
+    A line takes its span from the segment, but the characters are interpolated
+    across the *word* timings, and faster-whisper does not guarantee that a
+    segment's end equals its last word's end. When it does not, the final
+    character runs past the line — which TTML forbids outright ("the timestamp
+    of a child element must be completely contained within the timestamp of its
+    parent") and which makes a strict player clamp or drop the tail.
+
+    The word timings are the precise signal here, so the line yields to them.
+    """
+    if not chars:
+        return start, end
+    return min(start, chars[0]["start"]), max(end, chars[-1]["end"])
+
+
 def align(
     segments: list[Segment],
     lyrics: list[str],
@@ -81,15 +98,17 @@ def align(
                 # Single line, or no word timings: use the segment span as-is.
                 for k, line in enumerate(unit):
                     chars = char_timings(line, seg.words) if (karaoke and k == 0) else None
-                    results.append(AlignedLine(line, seg.start, seg.end,
+                    start, end = _containing(seg.start, seg.end, chars)
+                    results.append(AlignedLine(line, start, end,
                                                best_score, True, chars))
             else:
                 groups = split_words_by_breath(seg.words, unit)
                 for line, grp in zip(unit, groups):
                     if grp:
                         chars = char_timings(line, grp) if karaoke else None
-                        results.append(AlignedLine(line, grp[0].start,
-                                                   grp[-1].end, best_score, True, chars))
+                        start, end = _containing(grp[0].start, grp[-1].end, chars)
+                        results.append(AlignedLine(line, start, end,
+                                                   best_score, True, chars))
                     else:
                         results.append(AlignedLine(line, seg.start, seg.end,
                                                    best_score, True, None))

--- a/src/lyric_align/charmap.py
+++ b/src/lyric_align/charmap.py
@@ -67,44 +67,51 @@ def char_timings(text: str, words: list[Word]) -> list[dict]:
 def syllable_timings(text: str, chars: list[dict]) -> list[dict]:
     """Group per-character timings into the units a karaoke format highlights.
 
-    Returns [{"text", "start", "end"}]. The grouping differs by script, because
-    what counts as a "syllable" to highlight does:
+    Returns ``[{"text", "start", "end", "space_after"}]``. The grouping differs
+    by script, because what counts as a "syllable" to highlight does:
 
     - Alphabetic text is grouped on whitespace, so "Amazing grace" highlights two
       words rather than twelve letters.
     - CJK text keeps one unit per character, which is how per-character karaoke
       formats (QQ/NetEase style) treat Chinese and Japanese. Japanese lyrics often
       contain spaces as phrasing, so splitting on them would give useless chunks.
+
+    ``space_after`` records whether whitespace followed the unit *in the source
+    line*, so a formatter can rebuild the line exactly instead of guessing a
+    separator. The guess is what breaks CJK: a Japanese line is one unit per
+    character yet often carries a phrasing space, so any line-wide "is this
+    spaced text?" test either inserts a space between every character or drops
+    the phrasing space entirely.
     """
     if not chars:
         return []
-    if cjk_ratio(text) >= 0.2:
-        return [{"text": c["char"], "start": c["start"], "end": c["end"]} for c in chars]
+    per_char = cjk_ratio(text) >= 0.2
 
-    units: list[dict] = []
+    units: list[list] = []          # [source_text, [timings], space_after]
+    buf_text, buf_times = "", []
+
+    def flush() -> None:
+        nonlocal buf_text, buf_times
+        if buf_times:
+            units.append([buf_text, buf_times, False])
+        buf_text, buf_times = "", []
+
     it = iter(chars)
-    current: list[dict] = []
     for ch in text:
         if ch.isspace():
-            if current:
-                units.append(current)
-                current = []
+            flush()
+            if units:
+                units[-1][2] = True
             continue
         try:
-            current.append(next(it))
+            t = next(it)
         except StopIteration:
             break
-    if current:
-        units.append(current)
+        buf_text += ch
+        buf_times.append(t)
+        if per_char:
+            flush()
+    flush()
 
-    out = []
-    pos = 0
-    for group in units:
-        # Recover the original spelling: the char timings hold only the
-        # characters, so slice the source text by the same non-space run.
-        while pos < len(text) and text[pos].isspace():
-            pos += 1
-        word = text[pos:pos + len(group)]
-        pos += len(group)
-        out.append({"text": word, "start": group[0]["start"], "end": group[-1]["end"]})
-    return out
+    return [{"text": t, "start": ts[0]["start"], "end": ts[-1]["end"],
+             "space_after": sp} for t, ts, sp in units]

--- a/src/lyric_align/cli.py
+++ b/src/lyric_align/cli.py
@@ -226,18 +226,21 @@ def main(argv=None) -> int:
             log(f"only {matched}/{len(aligned)} lines matched from {len(segments)} "
                 f"segments — try " + ", or ".join(hints))
 
+    # TTML carries the language; the ASR language code is the one we know.
+    lang = args.language or ""
+
     if fmt == "all":
         base = Path(args.output)
         base = base.with_name(base.name[:-len(base.suffix)] if base.suffix else base.name)
         for name in targets:
             path = base.with_name(base.name + EXTENSIONS[name])
-            path.write_text(FORMATTERS[name](aligned, karaoke=karaoke))
+            path.write_text(FORMATTERS[name](aligned, karaoke=karaoke, lang=lang))
             log(f"wrote {path}")
     elif args.output:
-        Path(args.output).write_text(FORMATTERS[fmt](aligned, karaoke=karaoke))
+        Path(args.output).write_text(FORMATTERS[fmt](aligned, karaoke=karaoke, lang=lang))
         log(f"wrote {args.output}")
     else:
-        sys.stdout.write(FORMATTERS[fmt](aligned, karaoke=karaoke))
+        sys.stdout.write(FORMATTERS[fmt](aligned, karaoke=karaoke, lang=lang))
     return 0
 
 

--- a/src/lyric_align/formats.py
+++ b/src/lyric_align/formats.py
@@ -62,16 +62,21 @@ def to_elrc(aligned: list[AlignedLine]) -> str:
         if not units:
             lines.append(f"{_lrc_ts(a.start)}{a.line}")
             continue
-        body = "".join(f"<{_lrc_ts(u['start'])[1:-1]}>{u['text']}"
-                       + (" " if _spaced(a.line) and i < len(units) - 1 else "")
+        body = "".join(f"<{_lrc_ts(u['start'])[1:-1]}>{u['text']}{_gap(units, i)}"
                        for i, u in enumerate(units))
         lines.append(f"{_lrc_ts(a.start)}{body}")
     return "\n".join(lines) + "\n"
 
 
-def _spaced(line: str) -> bool:
-    """Whether syllable units should be re-joined with spaces (alphabetic text)."""
-    return " " in line.strip()
+def _gap(units: list[dict], i: int) -> str:
+    """The separator that followed unit ``i`` in the source line.
+
+    Taken from the line itself rather than guessed from the script, so both
+    "Amazing grace" and "硫黄が満ちる 道の奥" rebuild character-for-character.
+    A trailing space is dropped: lyric lines are stripped, and TTML consumers
+    trim it anyway.
+    """
+    return " " if units[i].get("space_after") and i < len(units) - 1 else ""
 
 
 def _srt_ts(t: float) -> str:
@@ -139,29 +144,48 @@ def to_ttml(aligned: list[AlignedLine], lang: str = "") -> str:
 
     Word timings become nested <span> elements inside the line <p>, which is what
     players in that ecosystem (e.g. AMLL) read for word-by-word highlighting.
+
+    Verified against the AMLL reference parser (``@applemusic-like-lyrics/ttml``):
+    lines, per-unit text and millisecond timings survive a real parse, and the
+    spaces between units are emitted as text nodes outside the spans, which is
+    the separator form that specification calls most compliant.
+
+    Only the metadata we actually know is written. A single ``ttm:agent`` is
+    declared and referenced because the spec requires one per line; the title,
+    artist and album an AMLL database submission also wants are left out rather
+    than invented, since this tool is given audio and lyrics and nothing else.
     """
     body = []
+    word_level = False
     for i, a in enumerate(aligned, 1):
         if _skip(a):
             continue
         units = syllable_timings(a.line, a.chars or [])
         p_open = (f'      <p begin="{_ttml_ts(a.start)}" end="{_ttml_ts(a.end)}" '
-                  f'itunes:key="L{i}">')
+                  f'itunes:key="L{i}" ttm:agent="v1">')
         if units:
-            joiner = " " if _spaced(a.line) else ""
-            inner = joiner.join(
+            word_level = True
+            inner = "".join(
                 f'<span begin="{_ttml_ts(u["start"])}" end="{_ttml_ts(u["end"])}">'
-                f'{escape(u["text"])}</span>' for u in units)
+                f'{escape(u["text"])}</span>{_gap(units, j)}'
+                for j, u in enumerate(units))
         else:
             inner = escape(a.line)
         body.append(f"{p_open}{inner}</p>")
-    lang_attr = f' xml:lang="{escape(lang)}"' if lang else ""
+    lang_attr = f'\n    xml:lang="{escape(lang)}"' if lang else ""
+    timing = "Word" if word_level else "Line"
     return (
         '<?xml version="1.0" encoding="UTF-8"?>\n'
         '<tt xmlns="http://www.w3.org/ns/ttml"\n'
         '    xmlns:ttm="http://www.w3.org/ns/ttml#metadata"\n'
         '    xmlns:itunes="http://music.apple.com/lyric-ttml-internal"'
-        f'{lang_attr}>\n'
+        f'{lang_attr}\n'
+        f'    itunes:timing="{timing}">\n'
+        '  <head>\n'
+        '    <metadata>\n'
+        '      <ttm:agent type="person" xml:id="v1"/>\n'
+        '    </metadata>\n'
+        '  </head>\n'
         '  <body>\n'
         '    <div>\n'
         + "\n".join(body) + "\n"
@@ -213,14 +237,14 @@ def to_ass(aligned: list[AlignedLine], karaoke: bool = False) -> str:
 
 
 FORMATTERS = {
-    "json": lambda a, karaoke=False: to_json(a),
-    "lrc": lambda a, karaoke=False: to_lrc(a),
-    "elrc": lambda a, karaoke=False: to_elrc(a),
-    "srt": lambda a, karaoke=False: to_srt(a),
-    "vtt": lambda a, karaoke=False: to_vtt(a),
-    "ass": lambda a, karaoke=False: to_ass(a, karaoke=karaoke),
-    "ttml": lambda a, karaoke=False: to_ttml(a),
-    "aud": lambda a, karaoke=False: to_aud(a),
+    "json": lambda a, karaoke=False, lang="": to_json(a),
+    "lrc": lambda a, karaoke=False, lang="": to_lrc(a),
+    "elrc": lambda a, karaoke=False, lang="": to_elrc(a),
+    "srt": lambda a, karaoke=False, lang="": to_srt(a),
+    "vtt": lambda a, karaoke=False, lang="": to_vtt(a),
+    "ass": lambda a, karaoke=False, lang="": to_ass(a, karaoke=karaoke),
+    "ttml": lambda a, karaoke=False, lang="": to_ttml(a, lang=lang),
+    "aud": lambda a, karaoke=False, lang="": to_aud(a),
 }
 
 # Formats whose whole point is per-syllable timing, so the CLI computes character

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -67,6 +67,81 @@ def test_ttml_wraps_syllables_in_spans_and_escapes():
     assert out.count("<span") >= 2
 
 
+def _ttml_lines(xml: str) -> list[str]:
+    """Rebuild each line from its spans the way a TTML consumer does."""
+    out = []
+    for inner in re.findall(r"<p [^>]*>(.*?)</p>", xml):
+        out.append(re.sub(r"</?span[^>]*>", "", inner))
+    return out
+
+
+def _elrc_line(elrc: str) -> str:
+    """Strip the line timestamp and the inline word timestamps from one eLRC line."""
+    body = re.sub(r"^\[\d\d:\d\d\.\d\d\]", "", elrc.strip())
+    return re.sub(r"<\d\d:\d\d\.\d\d>", "", body)
+
+
+def test_ttml_and_elrc_rebuild_the_source_line_exactly():
+    # A Japanese line carries a phrasing space *and* is one unit per character.
+    # Deciding the separator from the line ("does it contain a space?") breaks
+    # exactly here: it puts a space between every character and loses the real
+    # one. The separator has to come from the source text, per unit.
+    line = "硫黄が満ちる 道の奥"
+    a = AlignedLine(line, 0.0, 1.0, 0.9, True, char_timings(line, WORDS_JA))
+    assert _ttml_lines(to_ttml([a])) == [line]
+    assert _elrc_line(to_elrc([a])) == line
+
+    en = "Amazing grace"
+    b = AlignedLine(en, 0.0, 1.0, 0.9, True, char_timings(en, WORDS_EN))
+    assert _ttml_lines(to_ttml([b])) == [en]
+    assert _elrc_line(to_elrc([b])) == en
+
+
+def test_ttml_spans_stay_inside_their_line():
+    # TTML requires a child's span to be contained by its parent's; a strict
+    # player otherwise clamps or drops the tail.
+    for a in (en_line(), ja_line()):
+        xml = to_ttml([a])
+        for p_begin, p_end, inner in re.findall(
+                r'<p begin="([^"]+)" end="([^"]+)"[^>]*>(.*?)</p>', xml):
+            spans = re.findall(r'begin="([^"]+)" end="([^"]+)"', inner)
+            assert spans
+            assert spans[0][0] >= p_begin
+            assert spans[-1][1] <= p_end
+
+
+def test_align_widens_a_line_to_contain_its_characters():
+    # faster-whisper does not guarantee segment.end == last word end.
+    from lyric_align.anchor import align
+    from lyric_align.model import Segment
+    seg = Segment(0.0, 1.0, "amazing grace",
+                  [Word(0.0, 0.5, "amazing"), Word(0.5, 1.6, "grace")])
+    a = align([seg], ["Amazing grace"], pairing=1, karaoke=True)[0]
+    assert a.chars[-1]["end"] <= a.end
+    assert a.chars[0]["start"] >= a.start
+
+
+def test_ttml_declares_an_agent_and_the_language():
+    out = to_ttml([en_line()], lang="en")
+    assert '<ttm:agent type="person" xml:id="v1"/>' in out
+    assert 'ttm:agent="v1"' in out
+    assert 'xml:lang="en"' in out
+    assert 'itunes:timing="Word"' in out
+
+
+def test_ttml_language_comes_from_the_cli(tmp_path, capsys):
+    from lyric_align.cli import main
+    from pathlib import Path
+    fix = Path(__file__).parent / "fixtures" / "segments_sample.json"
+    lyrics = tmp_path / "l.txt"
+    lyrics.write_text("あかねさす紫野ゆき\n")
+    out = tmp_path / "o.ttml"
+    assert main([str(lyrics), "--segments", str(fix), "--pairing", "1",
+                 "--language", "ja", "-f", "ttml", "-o", str(out)]) == 0
+    assert 'xml:lang="ja"' in out.read_text()
+    capsys.readouterr()
+
+
 def test_unmatched_lines_are_absent_from_every_text_format():
     lines = [en_line(), AlignedLine("dropped line", None, None, 0.1, False, None)]
     for name, fmt in FORMATTERS.items():


### PR DESCRIPTION
Validated the `ttml` output against the AMLL reference parser
([`@applemusic-like-lyrics/ttml`](https://github.com/amll-dev/applemusic-like-lyrics))
rather than against the XML schema alone. The file parsed — which is all a
schema check would have told us — and two defects only a consumer could see
fell out.

### 1. CJK lost its text layout

Every Japanese line came back with a space between every character, and its real
phrasing space gone:

```
sent:   硫黄が満ちる 道の奥
parsed: 硫 黄 が 満 ち る 道 の 奥
```

70/70 lines wrong, 540 units falsely marked `endsWithSpace`. The separator was
decided per *line* — "does this line contain a space?" — which is the one test
that cannot work for the language this tool exists for. A Japanese lyric line is
one unit per character *and* routinely carries a phrasing space, so the answer is
always yes and the space lands in every gap. The separator now comes from the
source text per unit. `eLRC` shared the guess and is fixed with it.

### 2. Spans escaped their own line

A line's last character could end after the line did, which TTML forbids ("the
timestamp of a child element must be completely contained within the timestamp
of its parent") and which made the parser report an end time we never wrote.
A line takes its span from the ASR segment while its characters are interpolated
across the *word* timings, and faster-whisper does not guarantee
`segment.end == last word end`. The word timings are the precise signal, so the
line yields to them.

Rare (1 line in 12 with `--pairing 1`, 0 in 70 otherwise) and it moves line
*ends* only, so measured accuracy is unchanged: **19/20 mean 0.503s**,
**33/33 mean 0.944s**, `<=0.5s` 26/33 — identical to the README.

### Also

- Declare the `ttm:agent` the spec wants on every line.
- Wire `xml:lang`, which `to_ttml` accepted and the CLI never passed.
- Title/artist/album stay out. An AMLL *database submission* wants them, but this
  tool is handed audio and lyrics and nothing else; inventing them is worse than
  omitting them.

### Verification

Both scripts now round-trip exactly through the real parser:

```
=== EN (latin) ===  OK — 12 lines round-trip exactly
=== JA (CJK)   ===  OK — 70 lines round-trip exactly
```

checking line count, line text, per-unit rebuild honouring `endsWithSpace`,
millisecond line timings, monotonic non-overlapping words, and span containment.

New tests pin what a schema cannot: exact line reconstruction in both scripts,
spans contained by their line, the widening invariant in `align()`, and the
language reaching the file from the CLI. 38 pass.