### PR TITLE
feat: read Audacity labels back with --from-labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Whisper flavor produces.
 | `vtt` | WebVTT | HTML5 `<track>`, web players |
 | `ass` | styling + `\k` karaoke sweeps | Aegisub, `ffmpeg` burn-in |
 | `ttml` | per-syllable rich lyrics | Apple-style / AMLL-ecosystem players |
-| `aud` | Audacity label track (`start⇥end⇥text`) | **fixing the timings by hand**; also plain TSV |
+| `aud` | Audacity label track (`start⇥end⇥text`) | **fixing the timings by hand**, then `--from-labels` back into any format; also plain TSV |
 | `json` | everything, including scores and unmatched lines | your own code |
 
 Per-syllable formats split by script: alphabetic text is grouped into words
@@ -105,9 +105,11 @@ ffmpeg -i video.mp4 -vf "ass=out.ass" -c:a copy out.mp4
 # karaoke sweep instead of plain lines
 lyric-align song.wav lyrics.txt -f ass --karaoke -o out.ass
 
-# fix a mistimed line by hand: import out.labels.txt into Audacity
-#   (File > Import > Labels), drag it over the waveform, export the labels again
-lyric-align song.wav lyrics.txt -f aud -o out.labels.txt
+# fix a mistimed line by hand — the correction loop, in three steps
+lyric-align song.wav lyrics.txt -f aud -o out.labels.txt   # 1. export labels
+#   2. Audacity: File > Import > Labels, drag the wrong line over the waveform,
+#      then File > Export > Export Labels
+lyric-align --from-labels out.labels.txt -f lrc -o final.lrc   # 3. back to LRC
 
 # web player
 lyric-align song.wav lyrics.txt -f vtt -o out.vtt

--- a/src/lyric_align/cli.py
+++ b/src/lyric_align/cli.py
@@ -3,6 +3,7 @@
     lyric-align AUDIO LYRICS.txt -o out.lrc          # transcribe + align
     lyric-align AUDIO LYRICS.txt --separate -o o.lrc  # split vocals first (better)
     lyric-align --segments segs.json LYRICS.txt -f ass --karaoke
+    lyric-align --from-labels fixed.labels.txt -f lrc  # convert corrected labels
 
 LYRICS is a plain-text file, one lyric line per line. Blank lines and section
 markers ([Verse 1], [Hook]) are ignored, so pasted lyric sheets work as-is.
@@ -17,7 +18,7 @@ from pathlib import Path
 
 from . import __version__
 from .anchor import align, interpolate_gaps
-from .formats import EXTENSIONS, FORMATTERS, NEEDS_SYLLABLES
+from .formats import EXTENSIONS, FORMATTERS, NEEDS_SYLLABLES, from_aud
 from .model import Segment
 from .normalize import CJK_THRESHOLD, LATIN_THRESHOLD, default_threshold
 
@@ -55,10 +56,14 @@ examples:
   lyric-align song.wav lyrics.txt --separate -o out.lrc   split vocals first (better on a mix)
   lyric-align song.mp3 lyrics.txt --language en --no-vad  English, sung slowly
   lyric-align --segments segs.json lyrics.txt -f ass --karaoke
+  lyric-align --from-labels fixed.labels.txt -f lrc   convert labels you corrected
 
 LYRICS is plain text, one lyric line per line. Blank lines, # comments and
 section markers ([Verse 1], [Hook]) are skipped, so a pasted lyric sheet works
 as-is.
+
+To fix a timing by hand, write '-f aud', drag the line over the waveform in
+Audacity, export the labels, and read them back with --from-labels.
 """
 
 
@@ -66,7 +71,7 @@ def build_parser() -> argparse.ArgumentParser:
     p = argparse.ArgumentParser(prog="lyric-align", description=DESCRIPTION,
                                 formatter_class=argparse.RawDescriptionHelpFormatter)
     p.add_argument("audio", nargs="?", help="audio file (omit if --segments given)")
-    p.add_argument("lyrics", help="plain-text lyrics, one line per line")
+    p.add_argument("lyrics", nargs="?", help="plain-text lyrics, one line per line")
 
     out = p.add_argument_group("output")
     out.add_argument("-o", "--output", help="output path (default: stdout)")
@@ -78,6 +83,12 @@ def build_parser() -> argparse.ArgumentParser:
                      help="per-character timings, for karaoke \\k tags (ass/json). "
                           "Always on for elrc/ttml, which are per-syllable formats")
     out.add_argument("-q", "--quiet", action="store_true", help="suppress progress reporting")
+    out.add_argument("--from-labels", metavar="FILE",
+                     help="read an Audacity label track instead of aligning, and "
+                          "convert it to -f. This closes the correction loop: export "
+                          "'aud', drag the wrong lines over the waveform in Audacity, "
+                          "export the labels again, and turn them back into LRC/TTML/"
+                          "anything. Takes no AUDIO or LYRICS — the labels hold both")
 
     asr = p.add_argument_group(
         "transcription", "ignored when --segments is given")
@@ -121,16 +132,58 @@ def build_parser() -> argparse.ArgumentParser:
 def main(argv=None) -> int:
     args = build_parser().parse_args(argv)
 
+    # Both positionals are optional, so argparse fills AUDIO first. A lone
+    # positional can only be the lyrics — there is no aligning audio without
+    # them — so hand it over rather than reporting a missing LYRICS.
+    if args.lyrics is None and args.audio is not None:
+        args.audio, args.lyrics = None, args.audio
+
     def log(msg: str) -> None:
         if not args.quiet:
             print(msg, file=sys.stderr)
 
     for label, path in (("lyrics", args.lyrics), ("audio", args.audio),
-                        ("segments", args.segments)):
+                        ("segments", args.segments), ("labels", args.from_labels)):
         if path and not Path(path).exists():
             print(f"error: {label} file not found: {path}", file=sys.stderr)
             return 2
 
+    fmt = args.format
+    if fmt is None and args.output:
+        fmt = Path(args.output).suffix.lstrip(".").lower()
+    if fmt != "all" and fmt not in FORMATTERS:
+        fmt = "json"
+    if fmt == "all" and not args.output:
+        print("error: -f all needs -o to name the files to write", file=sys.stderr)
+        return 2
+    targets = sorted(FORMATTERS) if fmt == "all" else [fmt]
+    # Per-syllable formats are pointless without character timings, so turn them
+    # on for those rather than silently emitting line-level output.
+    karaoke = args.karaoke or bool(NEEDS_SYLLABLES.intersection(targets))
+
+    if args.from_labels:
+        # Converting a corrected label track: the file already holds the text and
+        # the times, so there is nothing to transcribe and nothing to match.
+        try:
+            aligned = from_aud(Path(args.from_labels).read_text())
+        except ValueError as e:
+            print(f"error: {args.from_labels}: {e}", file=sys.stderr)
+            return 2
+        if not aligned:
+            print(f"error: no labels found in {args.from_labels}", file=sys.stderr)
+            return 2
+        log(f"labels: {len(aligned)} (from {args.from_labels})")
+        if karaoke:
+            # Labels are line-level; per-syllable output would have to be invented.
+            log("note: a label track carries no per-character timings, so "
+                f"{'/'.join(sorted(NEEDS_SYLLABLES.intersection(targets))) or 'karaoke'} "
+                "output stays line-level")
+        return _write(args, fmt, targets, aligned, karaoke, log)
+
+    if not args.lyrics:
+        print("error: provide LYRICS (or --from-labels to convert a label track)",
+              file=sys.stderr)
+        return 2
     lyrics = read_lyrics(Path(args.lyrics))
     if not lyrics:
         print(f"error: no lyric lines found in {args.lyrics}", file=sys.stderr)
@@ -174,21 +227,6 @@ def main(argv=None) -> int:
         print("error: provide AUDIO or --segments", file=sys.stderr)
         return 2
 
-    fmt = args.format
-    if fmt is None and args.output:
-        fmt = Path(args.output).suffix.lstrip(".").lower()
-    if fmt != "all" and fmt not in FORMATTERS:
-        fmt = "json"
-
-    if fmt == "all" and not args.output:
-        print("error: -f all needs -o to name the files to write", file=sys.stderr)
-        return 2
-
-    targets = sorted(FORMATTERS) if fmt == "all" else [fmt]
-    # Per-syllable formats are pointless without character timings, so turn them
-    # on for those rather than silently emitting line-level output.
-    karaoke = args.karaoke or bool(NEEDS_SYLLABLES.intersection(targets))
-
     threshold = args.threshold
     if threshold is None:
         threshold = default_threshold(lyrics)
@@ -226,6 +264,10 @@ def main(argv=None) -> int:
             log(f"only {matched}/{len(aligned)} lines matched from {len(segments)} "
                 f"segments — try " + ", or ".join(hints))
 
+    return _write(args, fmt, targets, aligned, karaoke, log)
+
+
+def _write(args, fmt, targets, aligned, karaoke, log) -> int:
     # TTML carries the language; the ASR language code is the one we know.
     lang = args.language or ""
 

--- a/src/lyric_align/formats.py
+++ b/src/lyric_align/formats.py
@@ -132,6 +132,44 @@ def to_aud(aligned: list[AlignedLine]) -> str:
     return "\n".join(rows) + "\n"
 
 
+def from_aud(text: str) -> list[AlignedLine]:
+    """Read an Audacity label track back in — the other half of the round trip.
+
+    ``to_aud`` writes the timings out so a human can drag the wrong ones over the
+    waveform; this reads the corrected file, so the fix can leave as LRC, TTML or
+    anything else. No audio and no ASR: the label file already holds both the
+    text and the times.
+
+    Tolerates what Audacity actually writes: point labels (start == end, which a
+    click rather than a drag produces) and the ``\\t<low>\\t<high>`` continuation
+    row that a frequency-range label adds under its own text row.
+
+    Lines arrive with ``matched=True`` and ``score=1.0``. That is not a
+    similarity — nothing was matched here. It records that a human, not the
+    aligner, is the authority for these timings.
+    """
+    out: list[AlignedLine] = []
+    for n, raw in enumerate(text.splitlines(), 1):
+        if not raw.strip():
+            continue
+        if raw.startswith("\\"):
+            continue                      # frequency range for the label above
+        parts = raw.split("\t")
+        if len(parts) < 3:
+            raise ValueError(
+                f"line {n}: expected 'start<TAB>end<TAB>text', got {raw!r}")
+        try:
+            start, end = float(parts[0]), float(parts[1])
+        except ValueError:
+            raise ValueError(
+                f"line {n}: first two columns must be times, got {raw!r}") from None
+        label = "\t".join(parts[2:]).strip()
+        if not label:
+            continue                      # an unnamed marker is not a lyric line
+        out.append(AlignedLine(label, start, max(end, start), 1.0, True, None))
+    return out
+
+
 def _ttml_ts(t: float) -> str:
     h = int(t // 3600)
     m = int(t % 3600 // 60)

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -2,8 +2,8 @@ import json
 import re
 
 from lyric_align.charmap import char_timings, syllable_timings
-from lyric_align.formats import (EXTENSIONS, FORMATTERS, to_aud, to_elrc, to_ttml,
-                                 to_vtt)
+from lyric_align.formats import (EXTENSIONS, FORMATTERS, from_aud, to_aud, to_elrc,
+                                 to_ttml, to_vtt)
 from lyric_align.model import AlignedLine, Word
 
 WORDS_EN = [Word(0.0, 0.5, "Amazing"), Word(0.5, 1.0, "grace")]
@@ -140,6 +140,71 @@ def test_ttml_language_comes_from_the_cli(tmp_path, capsys):
                  "--language", "ja", "-f", "ttml", "-o", str(out)]) == 0
     assert 'xml:lang="ja"' in out.read_text()
     capsys.readouterr()
+
+
+def test_labels_round_trip_through_audacity_and_back():
+    # The correction loop: write labels, a human drags one, read them back.
+    lines = [en_line(), ja_line()]
+    exported = to_aud(lines)
+    corrected = exported.replace("0.000000\t1.000000\tAmazing grace",
+                                 "2.500000\t3.750000\tAmazing grace")
+    back = from_aud(corrected)
+    assert [a.line for a in back] == ["Amazing grace", "島の左近"]
+    assert (back[0].start, back[0].end) == (2.5, 3.75)
+    assert all(a.matched for a in back)
+    # Round-tripping an untouched file must not move anything.
+    assert to_aud(from_aud(exported)) == exported
+
+
+def test_from_aud_tolerates_what_audacity_actually_writes():
+    # A click rather than a drag gives a point label; a frequency-range label
+    # adds a continuation row beginning with a backslash.
+    text = ("1.000000\t1.000000\tpoint label\n"
+            "2.000000\t3.000000\tranged label\n"
+            "\\\t200.000000\t800.000000\n"
+            "\n")
+    got = from_aud(text)
+    assert [a.line for a in got] == ["point label", "ranged label"]
+    assert got[0].start == got[0].end == 1.0
+
+
+def test_from_aud_names_the_bad_line():
+    import pytest
+    with pytest.raises(ValueError, match="line 2"):
+        from_aud("0.0\t1.0\tfine\nnot a label row\n")
+    with pytest.raises(ValueError, match="line 1"):
+        from_aud("start\tend\ttext\n")
+
+
+def test_cli_converts_a_label_track_without_audio_or_lyrics(tmp_path, capsys):
+    from lyric_align.cli import main
+    labels = tmp_path / "in.labels.txt"
+    labels.write_text("6.600000\t14.300000\tAmazing grace\n"
+                      "14.300000\t23.700000\tThat saved a wretch like me\n")
+    out = tmp_path / "out.lrc"
+    assert main(["--from-labels", str(labels), "-o", str(out)]) == 0
+    assert out.read_text().splitlines() == [
+        "[00:06.60]Amazing grace",
+        "[00:14.30]That saved a wretch like me",
+    ]
+    capsys.readouterr()
+
+
+def test_cli_says_a_label_track_cannot_give_per_syllable_output(tmp_path, capsys):
+    from lyric_align.cli import main
+    labels = tmp_path / "in.labels.txt"
+    labels.write_text("0.000000\t1.000000\tAmazing grace\n")
+    out = tmp_path / "out.ttml"
+    assert main(["--from-labels", str(labels), "-o", str(out)]) == 0
+    assert "stays line-level" in capsys.readouterr().err
+    xml = out.read_text()
+    assert "Amazing grace" in xml and "<span" not in xml
+
+
+def test_cli_reports_a_missing_lyrics_argument(capsys):
+    from lyric_align.cli import main
+    assert main([]) == 2
+    assert "--from-labels" in capsys.readouterr().err
 
 
 def test_unmatched_lines_are_absent_from_every_text_format():


### PR DESCRIPTION
The label track was a one-way street. Its whole reason for existing is that a
human can see a wrong hook placement on the waveform and drag it into place —
but there was no way to get the corrected file back out, so the fix died in
Audacity.

```bash
lyric-align song.wav lyrics.txt -f aud -o out.labels.txt
# Audacity: File > Import > Labels, drag the wrong line, File > Export > Labels
lyric-align --from-labels out.labels.txt -f lrc -o final.lrc
```

No audio and no ASR on the way back — the label file already holds the text and
the times, so this is a pure conversion.

### Verified on real data

Exported 70 Japanese lines, moved line 2 by +1.5s the way a drag would, read it
back:

```
labels:  10.490000  誇り持ち散る 死の毒     ->  11.990000
LRC:     [00:11.99]誇り持ち散る 死の毒
```

The correction lands, and the Japanese phrasing space survives the trip.

### Details

- **Tolerates what Audacity actually writes**, not an idealised TSV: point labels
  (a click rather than a drag, `start == end`) and the `\<low>\<high>`
  continuation row a frequency-range label adds under its own text row.
- **A row it cannot read names its line number** instead of being dropped
  quietly — the same contract as an unmatched lyric line.
- **`matched=True`, `score=1.0`.** Not a similarity; nothing was matched. It
  records that a human, not the aligner, is the authority for these timings.
- **Labels are line-level**, so `elrc`/`ttml`/`--karaoke` cannot give per-syllable
  output from them. Rather than inventing character timings, the CLI says so and
  TTML declares `itunes:timing="Line"` — which the AMLL parser reads back
  correctly (70 lines, `timingMode: "Line"`).

### Regression fixed on the way

Making `LYRICS` optional meant a lone positional started landing in `AUDIO`,
which broke every `--segments` invocation (caught by the existing tests). A
single positional can only be the lyrics — there is no aligning audio without
them — so it is now handed over explicitly.

44 tests pass.