### PR TITLE
docs: record the measured failure of a timing prior for repeated hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,36 @@ above, "Through many dangers, toils and snares" was placed on the line
   Telling repetitions apart needs a timing prior, not a better search over
   similarity. Meanwhile the forward window is doing real work: it stops a line
   from reaching a distant segment that happens to clear the threshold.
+
+  A timing prior was then tried, and also measured worse. Scoring candidates by
+  `similarity − λ·|start − predicted|`, where `predicted` is the last placement
+  plus the running median gap:
+
+  | λ | lines placed | mean \|err\| | within 0.5 s | worst |
+  |---|---|---|---|---|
+  | 0 (shipped) | 33/33 | **0.94 s** | **26/33** | **6.4 s** |
+  | 0.1 | 33/33 | 1.67 s | 21/33 | 10.6 s |
+  | 0.3 | 33/33 | 2.05 s | 19/33 | 10.6 s |
+  | 0.5 | 8/33 | — | 7/33 | — |
+
+  The prior predicts from the aligner's own previous placements, so it cannot
+  correct a bad one — it anchors on it and drags the next lines along, which is
+  why the worst case grows rather than shrinks. Songs also do not run at one
+  pace: a median gap mispredicts hardest across a section boundary, which is
+  exactly where repeated hooks sit.
+
+  Restricting the prior to breaking near-ties (candidates within ε similarity,
+  never overturning a clear winner) is the only variant that does not hurt, and
+  it does not clearly help either: ε=0.02 moved one line into the ≤0.5 s bucket
+  (26→27) and the mean by 0.07 s; ε=0.05 left the buckets alone and cut the
+  worst case to 5.7 s; ε=0.10 collapsed back to the harmful regime. The second
+  track was unchanged at every ε. A 0.07 s shift is below the 1 s resolution of
+  that track's ground truth, so there is no measurement here to ship on — and
+  the useful ε sits directly beside a harmful one. Left out.
+
+  A prior that would actually work has to come from a signal independent of the
+  aligner's output — audio-side section detection, say — which is a different
+  tool with a much heavier dependency than a stdlib core.
 - **Slow, sustained singing is much harder than rap** — hymns, ballads and
   school songs stretch vowels until the ASR stops producing usable segments.
   Reach for `--no-vad` first (see the one-minute example); dense, consonant-rich

--- a/src/lyric_align/anchor.py
+++ b/src/lyric_align/anchor.py
@@ -14,6 +14,17 @@ extra placements land on the wrong repetition: mean error 0.94 s -> 1.14-1.61 s,
 worst 6.4 s -> 10.6 s on a track with a 4x-repeated hook. Locality beats global
 optimality here because similarity alone cannot tell repetitions apart.
 
+A timing prior — score candidates by `similarity - lam * |start - predicted|`,
+predicting from the last placement plus the running median gap — was the obvious
+next move and also measured worse (mean 0.94 s -> 1.67 s at lam=0.1, worst
+6.4 s -> 10.6 s, collapsing to 8/33 placements by lam=0.5). It predicts from
+*our own* previous placements, so it cannot correct a bad one; it anchors on it
+and drags the following lines along. Songs do not run at one pace either, so a
+median gap mispredicts hardest across a section boundary — where repeated hooks
+live. Restricted to breaking near-ties it stops hurting without clearly helping
+(one line gained, below the ground truth's own resolution), so it is not here.
+See the README for the full sweep.
+
 Design philosophy: when a line cannot be confidently matched, we mark it
 unmatched rather than inventing a timestamp. Forced aligners always emit an
 answer and thus fail *silently* (e.g. drifting into the intro); we prefer honest


### PR DESCRIPTION
The README already said that telling repetitions apart "needs a timing prior,
not a better search over similarity". That was the obvious next move after the
global matcher, so it was built and measured. **It is worse.**

Scoring candidates by `similarity − λ·|start − predicted|`, predicting from the
last placement plus the running median gap:

| λ | lines placed | mean \|err\| | within 0.5 s | worst |
|---|---|---|---|---|
| 0 (shipped) | 33/33 | **0.94 s** | **26/33** | **6.4 s** |
| 0.1 | 33/33 | 1.67 s | 21/33 | 10.6 s |
| 0.3 | 33/33 | 2.05 s | 19/33 | 10.6 s |
| 0.5 | 8/33 | — | 7/33 | — |

### Why — two mechanisms, both general

1. **The prior predicts from the aligner's own previous placements**, so it
   cannot correct a bad one. It anchors on it and drags the following lines
   along — which is why the *worst* case grows rather than shrinks.
2. **Songs do not run at one pace.** A median gap mispredicts hardest across a
   section boundary, which is exactly where repeated hooks sit.

### The ceiling was measured first

A diagnostic asked whether the correct segment was even reachable. Of 33 units
with ground truth: 27 already right, 1 with no correct candidate in the window,
and **5 reachable** — but 3 of those 5 needed to overturn a similarity margin of
**0.15–0.26**, and a prior strong enough to do that also applies to the 27 that
are right. Only 2 were near-ties.

(That diagnostic initially reported 11 unreachable units. Its own GT assignment
picked the *most similar* ground-truth row, so every repetition of a hook
collapsed onto the first one — the same failure the DP has. Assigning GT
monotonically fixed it. Worth noting because the measuring tool can fall into
the exact trap it is measuring.)

### So the safe variant was tried too

Restricted to breaking near-ties, never overturning a clear winner:

| ε | kurosuna mean | ≤0.5 s | worst | sugitaru |
|---|---|---|---|---|
| 0 (shipped) | 0.94 s | 26/33 | 6.4 s | unchanged |
| 0.02 | 0.88 s | 27/33 | 6.4 s | unchanged |
| 0.05 | 0.92 s | 26/33 | 5.7 s | unchanged |
| 0.10 | 1.67 s | 21/33 | 10.6 s | unchanged |

This is the only variant that does not hurt, and it does not clearly help. That
track's ground truth has **1 s resolution**, so a 0.07 s mean shift is not a
measurement — and the useful ε sits directly beside a harmful one. Not shipped.

### Why write it down

The README pointed at a timing prior as the answer, and it is not one. A prior
that works has to come from a signal **independent of the aligner's output** —
audio-side section detection — which is a different tool with a much heavier
dependency than a stdlib core.

Docs and docstring only; no behaviour change. 44 tests pass.