### PR TITLE
docs: name where this came from, and scope the license to the code

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -19,3 +19,19 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+---
+
+Scope of this license
+
+The MIT license above applies to the software in this repository: the source
+code, the tests and the documentation.
+
+It does not apply to the song lyrics quoted in this repository. Short lyric
+fragments appear in the test fixtures as sample input. They are the copyrighted
+work of their author (屠龍 / TORYU) and are reproduced here as test data only;
+no license to reuse them is granted by this file.
+
+The exception is examples/amazing_grace.txt, which is a public-domain hymn text
+and carries no such restriction. It is the example used in the README so that
+the walkthrough can be reproduced by anyone.

--- a/README.md
+++ b/README.md
@@ -215,6 +215,24 @@ filled (they stay flagged as guessed).
 The core (steps 3–5) is **pure Python standard library** — no numpy, no torch.
 The heavy pieces (Whisper, Demucs) are optional extras behind lazy imports.
 
+## Where this came from
+
+This was written to put lyrics on the timeline for a set of music videos, where
+the lyrics are Japanese and the delivery is rap. That is the whole reason the
+matcher compares characters instead of words, and why the accuracy below is
+measured on sung Japanese rather than on read speech.
+
+The two tracks the numbers come from are
+[過ぎたるもの](https://youtu.be/cpXhuZK5rug) (20 lines, ±0.5 s ground truth) and
+[黒砂の誓い](https://youtu.be/b8mjRge4Ffk) (33 lines, 1 s granularity). Others
+from the same catalogue: [六の巷](https://youtu.be/OIonX0bZjmI),
+[永遠の炎](https://youtu.be/lZIW59t9O-M) — [toryu.tokyo](https://toryu.tokyo).
+
+Short lyric fragments from those tracks appear in the test fixtures. They are the
+author's own work and are **not** covered by this project's MIT license; see
+[LICENSE](LICENSE). The runnable example (`examples/amazing_grace.txt`) is public
+domain, so anyone can reproduce it end to end.
+
 ## Accuracy
 
 Measured against 20 human-marked lyric lines of a 4-minute Japanese rap track


### PR DESCRIPTION
Pre-flight for going public.

### The license said more than intended

The test fixtures quote short lyric fragments from the tracks this tool was
written for, and `LICENSE` is a bare MIT covering everything in the repository.
Read plainly, that licenses the lyrics too — which was never the intent.

`LICENSE` now states its scope: the MIT terms cover the **code, tests and
documentation**. The quoted lyric fragments are the author's own copyrighted
work, present as test data, and not licensed by that file.
`examples/amazing_grace.txt` is called out as the exception — a public-domain
hymn, which is why the README walkthrough uses it and why **anyone can reproduce
that run end to end**.

### Where this came from

A short README section saying what the tool was built for. This is not a pitch —
it is the answer to two questions a reader will have:

- why does the matcher compare *characters* instead of words?
- why is the accuracy table measured on *sung Japanese* rather than read speech?

The two tracks the numbers come from are named and linked, because a reader who
wants to judge the ground truth should be able to hear it: 過ぎたるもの (20 lines,
±0.5 s) and 黒砂の誓い (33 lines, 1 s granularity). Both links verified reachable.

44 tests pass. Docs and license text only.