### PR TITLE
fix: keep LICENSE detectable as MIT, move the carve-out to NOTICE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -19,19 +19,3 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
-
----
-
-Scope of this license
-
-The MIT license above applies to the software in this repository: the source
-code, the tests and the documentation.
-
-It does not apply to the song lyrics quoted in this repository. Short lyric
-fragments appear in the test fixtures as sample input. They are the copyrighted
-work of their author (屠龍 / TORYU) and are reproduced here as test data only;
-no license to reuse them is granted by this file.
-
-The exception is examples/amazing_grace.txt, which is a public-domain hymn text
-and carries no such restriction. It is the example used in the README so that
-the walkthrough can be reproduced by anyone.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,15 @@
+Scope of the MIT license
+========================
+
+The MIT license in LICENSE applies to the software in this repository: the
+source code, the tests and the documentation.
+
+It does not grant any rights to the song lyrics quoted here. Short lyric
+fragments appear in the test fixtures as sample input. They are the
+copyrighted work of their author (屠龍 / TORYU), reproduced as test data only.
+Reusing them is not covered by LICENSE.
+
+The exception is examples/amazing_grace.txt. "Amazing Grace" is a public-domain
+hymn, and the recording the README points at is a public-domain work of the
+United States Air Force Reserve Band. That is why the README walkthrough uses
+it: anyone can reproduce that run end to end.

--- a/README.md
+++ b/README.md
@@ -229,8 +229,8 @@ from the same catalogue: [六の巷](https://youtu.be/OIonX0bZjmI),
 [永遠の炎](https://youtu.be/lZIW59t9O-M) — [toryu.tokyo](https://toryu.tokyo).
 
 Short lyric fragments from those tracks appear in the test fixtures. They are the
-author's own work and are **not** covered by this project's MIT license; see
-[LICENSE](LICENSE). The runnable example (`examples/amazing_grace.txt`) is public
+author's own work and are **not** covered by this project's MIT license — see
+[NOTICE](NOTICE). The runnable example (`examples/amazing_grace.txt`) is public
 domain, so anyone can reproduce it end to end.
 
 ## Accuracy
@@ -341,4 +341,5 @@ with a CJK-first matcher and honest-gap semantics.
 
 ## License
 
-MIT
+MIT, for the code, tests and documentation. The song lyrics quoted in the test
+fixtures are not covered by it — see [NOTICE](NOTICE).


### PR DESCRIPTION
Appending the scope note to `LICENSE` in #11 made GitHub's license detector give
up. The freshly public repository reported `NOASSERTION` and showed **no license
badge**, which reads as all-rights-reserved to anyone deciding whether to depend
on it — the opposite of what a public tool wants.

`LICENSE` is pristine MIT again so it is detected. The carve-out moves to
`NOTICE`, linked from README in both the origin section and the license section.

The substance is unchanged: MIT covers the code, tests and documentation; the
quoted lyric fragments are the author's own work and are not licensed by it;
`examples/amazing_grace.txt` is the public-domain exception (hymn and recording
both).

44 tests pass.