### PR TITLE
docs: record four measured failures to fix the remaining outlier

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,42 @@ above, "Through many dangers, toils and snares" was placed on the line
   A prior that would actually work has to come from a signal independent of the
   aligner's output — audio-side section detection, say — which is a different
   tool with a much heavier dependency than a stdlib core.
+- **Correcting one placement tends to break the next one.** The first track's
+  worst case (3.6 s) has a fully diagnosed cause: `SequenceMatcher.ratio()`
+  divides by *both* strings' lengths, so a short segment matching only the
+  second half of a two-line unit outscores the longer segment that actually
+  starts it (0.615 vs 0.304; concatenating both gives 0.644, and the right
+  answer wins). Three independent fixes follow from that, and a fourth from how
+  a global character aligner gets sub-segment resolution. All four fix the
+  outlier. All four cost more elsewhere than they return:
+
+  | candidate selection | 過ぎたるもの mean / worst / ≤0.5 s | 黒砂 matched / mean / ≤0.5 s |
+  |---|---|---|
+  | forward scan (shipped) | **0.50 s** / 3.6 s / **14/20** | **33/33** / **0.94 s** / **26/33** |
+  | span up to 2 segments | 0.34 s / **0.7 s** / 15/20 | 29/33 / 2.13 s / 23/33 |
+  | score the unit's opening, not the whole unit | 0.34 s / **0.7 s** / 15/20 | 31/33 / 1.22 s / 23/33 |
+  | veto candidates matching only the unit's tail | 0.33 s / **0.7 s** / 14/20 | 32/33 / 1.74 s / 19/33 |
+  | ↑ but only on lines that never repeat | 0.34 s / **0.7 s** / 15/20 | 32/33 / 1.00 s / 25/33 |
+
+  The mechanism is the scan itself. `idx` advances to just past whatever was
+  chosen, so *every* neighbour is downstream of *every* decision. Gains and
+  losses arrive in adjacent pairs: the last row above fixes 2.30 s → 0.02 s at
+  2:20 on the second track and breaks 0.32 s → 3.70 s at 2:26, six seconds
+  later. Across both tracks it nets to two lines fixed, one broken, one turned
+  into a gap, on 53 measured lines — which is not an improvement, it is noise.
+  Local accuracy does not compose in a greedy monotone scan, and that is why
+  four unrelated interventions all land on roughly the same total.
+
+  The fourth is worth naming separately because it is what the one comparable
+  tool does differently. Taking each line's start from the word its first
+  character lands on — the sub-segment resolution a global character aligner
+  buys — measured *worse on both tracks* (mean 0.50 → 0.79 s and 0.94 → 1.26 s;
+  ≤0.5 s 14/20 → 9/20 and 26/33 → 20/33). Placements are already late (signed
+  mean +0.46 s and +0.21 s), and refining into the segment can only add
+  lateness. A sung phrase begins at its breath and attack, before the first word
+  the ASR is willing to timestamp, so the segment boundary is the better
+  estimate of onset — and the same thing that buys a global aligner a shorter
+  tail costs it the body.
 - **Slow, sustained singing is much harder than rap** — hymns, ballads and
   school songs stretch vowels until the ASR stops producing usable segments.
   Reach for `--no-vad` first (see the one-minute example); dense, consonant-rich

--- a/src/lyric_align/anchor.py
+++ b/src/lyric_align/anchor.py
@@ -25,6 +25,19 @@ live. Restricted to breaking near-ties it stops hurting without clearly helping
 (one line gained, below the ground truth's own resolution), so it is not here.
 See the README for the full sweep.
 
+Four further attempts to fix the remaining outlier — letting a candidate span
+two consecutive segments, scoring candidates on how well they explain the unit's
+*opening* rather than the whole unit, vetoing candidates that match only its
+tail, and taking the start from the word the first character lands on — all
+worked, and all cost more than they returned. The first three share a mechanism:
+`idx` advances to just past whatever was chosen, so every neighbour is
+downstream of every decision, and gains and losses arrive in adjacent pairs (the
+best variant fixes 2.30 s -> 0.02 s at 2:20 on one track and breaks
+0.32 s -> 3.70 s at 2:26). The fourth fails differently: placements are already
+late (signed mean +0.46 s / +0.21 s) because a sung phrase begins at its breath
+and attack, earlier than the first word an ASR will timestamp, so refining into
+the segment only adds lateness. See the README for both tables.
+
 Design philosophy: when a line cannot be confidently matched, we mark it
 unmatched rather than inventing a timestamp. Forced aligners always emit an
 answer and thus fail *silently* (e.g. drifting into the intro); we prefer honest


### PR DESCRIPTION
The remaining 3.6 s outlier on the first track has a fully diagnosed cause:
`SequenceMatcher.ratio()` normalises by *both* strings' lengths, so a short
segment matching only a two-line unit's second half outscores the longer segment
that actually starts it (0.615 vs 0.304; concatenating both gives 0.644 and the
right answer wins).

Three fixes follow directly from that diagnosis, and a fourth from how a global
character aligner buys sub-segment resolution. **All four fix the outlier. All
four cost more elsewhere than they return.** Nothing is adopted here — this PR
is documentation plus the diagnosis, so the next person does not spend the
afternoon rediscovering it.

## Candidate selection (three variants)

| candidate selection | 過ぎたるもの mean / worst / ≤0.5 s | 黒砂 matched / mean / ≤0.5 s |
|---|---|---|
| forward scan (shipped) | **0.50 s** / 3.6 s / **14/20** | **33/33** / **0.94 s** / **26/33** |
| span up to 2 segments | 0.34 s / **0.7 s** / 15/20 | 29/33 / 2.13 s / 23/33 |
| score the unit's opening | 0.34 s / **0.7 s** / 15/20 | 31/33 / 1.22 s / 23/33 |
| veto tail-only candidates | 0.33 s / **0.7 s** / 14/20 | 32/33 / 1.74 s / 19/33 |
| ↑ only on non-repeating lines | 0.34 s / **0.7 s** / 15/20 | 32/33 / 1.00 s / 25/33 |

The mechanism is the scan itself: `idx` advances to just past whatever was
chosen, so every neighbour is downstream of every decision. Gains and losses
arrive in adjacent pairs — the last row fixes 2.30 s → 0.02 s at 2:20 and breaks
0.32 s → 3.70 s at 2:26, six seconds later. Across both tracks: two lines fixed,
one broken, one turned into a gap, on 53 measured lines. That is noise, not an
improvement.

This also explains the shape of the three earlier negative results (global DP,
timing prior, and now this): local accuracy does not compose in a greedy
monotone scan, so unrelated interventions all land on roughly the same total.

## Sub-segment start refinement (the fourth)

Worth naming separately because it is what the one comparable tool does
differently. Taking each line's start from the word its first character lands on
measured **worse on both tracks**: mean 0.50 → 0.79 s and 0.94 → 1.26 s, ≤0.5 s
14/20 → 9/20 and 26/33 → 20/33.

Placements are already late (signed mean +0.46 s and +0.21 s), and refining into
the segment can only add lateness. A sung phrase begins at its breath and
attack, before the first word an ASR is willing to timestamp — so the segment
boundary is the better estimate of onset, and the same thing that buys a global
aligner a shorter tail costs it the body.

## Notes

- No code change. `align()` is byte-identical to `main`; 44 tests pass.
- Sweeps live in the bench harness (`toryu-web/scratchpad/lyrics_align_bench/`,
  `exp_max_span.py`, `exp_span_variants.py`, `exp_prefix_score.py`,
  `exp_tail_veto.py`, `exp_unique_gate.py`, `exp_word_refine.py`) with their
  JSON outputs, so every number above is re-runnable from the cached ASR.
- Every variant looks adoptable if you only measure the first track — worst
  3.58 s → 0.70 s with no line made worse. The cost is entirely on the other
  one. The bench README now says so explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)