### PR TITLE
ci: test matrix + PyPI publish via Trusted Publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # Both ends of the supported range, plus the current default. The core
+        # has no dependencies, so this is the whole compatibility surface.
+        python-version: ["3.9", "3.12", "3.14"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+      - run: uv venv --python ${{ matrix.python-version }}
+      - run: uv pip install pytest
+      - run: uv run --no-project pytest -q

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,66 @@
+name: publish
+
+# Publishes to PyPI when a GitHub Release is published. Uses Trusted Publishing
+# (OIDC), so there is no API token stored anywhere — PyPI verifies the workflow
+# identity instead. Configure the publisher once at
+# https://pypi.org/manage/account/publishing/ with:
+#   PyPI project name : lyric-align
+#   Owner             : ijuinryukichi
+#   Repository name   : lyric-align
+#   Workflow name     : publish.yml
+#   Environment name  : pypi
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.9", "3.14"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+      - run: uv venv --python ${{ matrix.python-version }}
+      - run: uv pip install pytest
+      - run: uv run --no-project pytest -q
+
+  build:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+      - run: uv build
+      # A malformed long_description is only caught here, not by the build.
+      - run: uvx twine check dist/*
+      # The tag must match the version being published, or a mistyped release
+      # silently ships the previous version under a new name.
+      - name: Check the tag matches the package version
+        if: github.event_name == 'release'
+        run: |
+          version=$(python3 -c "import tomllib;print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
+          tag="${GITHUB_REF_NAME#v}"
+          echo "pyproject: $version / tag: $tag"
+          [ "$version" = "$tag" ] || { echo "::error::tag $tag != version $version"; exit 1; }
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write  # required for Trusted Publishing; no secret involved
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+      - uses: pypa/gh-action-pypi-publish@release/v1

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # lyric-align
 
+[![PyPI](https://img.shields.io/pypi/v/lyric-align)](https://pypi.org/project/lyric-align/)
+[![Python](https://img.shields.io/pypi/pyversions/lyric-align)](https://pypi.org/project/lyric-align/)
+[![tests](https://github.com/ijuinryukichi/lyric-align/actions/workflows/ci.yml/badge.svg)](https://github.com/ijuinryukichi/lyric-align/actions/workflows/ci.yml)
+[![License](https://img.shields.io/pypi/l/lyric-align)](LICENSE)
+
 **You already have the correct lyrics. You only need the *times*.**
 
 `lyric-align` anchors known lyric lines onto ASR word timings by *character-level*


### PR DESCRIPTION
Two workflows, no stored secrets.

**`ci.yml`** — runs the suite on 3.9 / 3.12 / 3.14 for every push and PR. The
core has no dependencies, so that matrix is the entire compatibility surface.

**`publish.yml`** — publishes to PyPI when a GitHub Release is published, using
Trusted Publishing (OIDC). Nothing long-lived is stored: PyPI verifies the
workflow identity instead of a token.

Gates before anything is uploaded:

1. the suite passes on both ends of the supported range
2. `twine check` on the built wheel and sdist
3. the git tag matches `project.version` in `pyproject.toml` — without this a
   mistyped tag ships the *previous* version under a new name, which cannot be
   undone because PyPI never lets a version number be reused

Also adds PyPI / Python / tests / license badges to the README. The PyPI ones
resolve once the first release lands.

## Verified before committing

- `uv venv` → `uv pip install pytest` → `uv run --no-project pytest -q` reproduced
  against a copy of the tree: 44 passed
- version extraction (`tomllib` on the runner's python3) returns `0.3.0`
- both workflow files parse and the job graph is `test → build → publish`, with
  `id-token: write` scoped to the publish job only

## Remaining manual step

Register the publisher once at https://pypi.org/manage/account/publishing/ —
project `lyric-align`, owner `ijuinryukichi`, repo `lyric-align`, workflow
`publish.yml`, environment `pypi`. Since the project does not exist on PyPI yet
this is a *pending* publisher, which is the supported way to claim a new name
without ever creating a token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)