### PR TITLE
feat: --meta, so a TTML file can be an AMLL database submission

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,27 @@ lyric-align --from-labels out.labels.txt -f lrc -o final.lrc   # 3. back to LRC
 
 # web player
 lyric-align song.wav lyrics.txt -f vtt -o out.vtt
+
+# a file shaped for an AMLL TTML DB submission
+lyric-align song.wav lyrics.txt -f ttml -o out.ttml \
+  --meta musicName="Song" --meta artists="Artist" --meta album="Album" \
+  --meta ncmMusicId=1234567
 ```
+
+The [AMLL TTML DB](https://github.com/amll-dev/amll-ttml-db) is the largest open
+collection of word-by-word lyric files — tens of thousands of them, timed by
+hand. Its checker requires `musicName`, `artists`, `album` and at least one
+platform id (`ncmMusicId` / `appleMusicId` / `spotifyId` / `qqMusicId`), none of
+which can be inferred from audio and lyrics, so `--meta` is how you supply them.
+Everything else was already in the right shape: one `<span>` per CJK character,
+spaces as text nodes *between* spans (the form their spec calls most compliant),
+and every child timestamp contained by its parent.
+
+Checked, not assumed — the output parses with the AMLL reference parser
+(`@applemusic-like-lyrics/ttml`) and clears every rule in the database's own
+checker (`scripts/lyric_checker_bot/src/validator.rs`): 70 lines, 623 syllables,
+metadata read back intact. Without `--meta` the same file fails on exactly the
+four metadata rules, which is the point of the flag.
 
 Formats deliberately left out: UltraStar `.txt` and CDG need sung **pitch**, not
 just timing — [UltraSinger](https://github.com/rakuri255/UltraSinger) and

--- a/src/lyric_align/cli.py
+++ b/src/lyric_align/cli.py
@@ -82,6 +82,12 @@ def build_parser() -> argparse.ArgumentParser:
     out.add_argument("--karaoke", action="store_true",
                      help="per-character timings, for karaoke \\k tags (ass/json). "
                           "Always on for elrc/ttml, which are per-syllable formats")
+    out.add_argument("--meta", metavar="KEY=VALUE", action="append",
+                     help="metadata for the TTML head, repeatable. An AMLL "
+                          "database submission requires musicName, artists, album "
+                          "and one platform id (ncmMusicId / appleMusicId / "
+                          "spotifyId / qqMusicId); this tool only sees audio and "
+                          "lyrics, so those have to come from you")
     out.add_argument("-q", "--quiet", action="store_true", help="suppress progress reporting")
     out.add_argument("--from-labels", metavar="FILE",
                      help="read an Audacity label track instead of aligning, and "
@@ -267,22 +273,37 @@ def main(argv=None) -> int:
     return _write(args, fmt, targets, aligned, karaoke, log)
 
 
+def _parse_meta(pairs) -> dict:
+    """``--meta key=value`` into a dict, preserving the order they were given."""
+    meta = {}
+    for raw in pairs or []:
+        key, sep, value = raw.partition("=")
+        if not sep or not key.strip():
+            raise SystemExit(f"--meta expects key=value, got {raw!r}")
+        meta[key.strip()] = value.strip()
+    return meta
+
+
 def _write(args, fmt, targets, aligned, karaoke, log) -> int:
     # TTML carries the language; the ASR language code is the one we know.
     lang = args.language or ""
+    meta = _parse_meta(getattr(args, "meta", None))
 
     if fmt == "all":
         base = Path(args.output)
         base = base.with_name(base.name[:-len(base.suffix)] if base.suffix else base.name)
         for name in targets:
             path = base.with_name(base.name + EXTENSIONS[name])
-            path.write_text(FORMATTERS[name](aligned, karaoke=karaoke, lang=lang))
+            path.write_text(FORMATTERS[name](aligned, karaoke=karaoke, lang=lang,
+                                             meta=meta))
             log(f"wrote {path}")
     elif args.output:
-        Path(args.output).write_text(FORMATTERS[fmt](aligned, karaoke=karaoke, lang=lang))
+        Path(args.output).write_text(
+            FORMATTERS[fmt](aligned, karaoke=karaoke, lang=lang, meta=meta))
         log(f"wrote {args.output}")
     else:
-        sys.stdout.write(FORMATTERS[fmt](aligned, karaoke=karaoke, lang=lang))
+        sys.stdout.write(
+            FORMATTERS[fmt](aligned, karaoke=karaoke, lang=lang, meta=meta))
     return 0
 
 

--- a/src/lyric_align/formats.py
+++ b/src/lyric_align/formats.py
@@ -177,7 +177,8 @@ def _ttml_ts(t: float) -> str:
     return f"{h:02d}:{m:02d}:{s:06.3f}"
 
 
-def to_ttml(aligned: list[AlignedLine], lang: str = "") -> str:
+def to_ttml(aligned: list[AlignedLine], lang: str = "",
+            meta: dict | None = None) -> str:
     """TTML with per-syllable spans — the shape Apple-style rich lyrics use.
 
     Word timings become nested <span> elements inside the line <p>, which is what
@@ -188,10 +189,11 @@ def to_ttml(aligned: list[AlignedLine], lang: str = "") -> str:
     spaces between units are emitted as text nodes outside the spans, which is
     the separator form that specification calls most compliant.
 
-    Only the metadata we actually know is written. A single ``ttm:agent`` is
-    declared and referenced because the spec requires one per line; the title,
-    artist and album an AMLL database submission also wants are left out rather
-    than invented, since this tool is given audio and lyrics and nothing else.
+    ``meta`` is written out as ``<amll:meta>`` entries. Nothing here is invented:
+    this tool is handed audio and lyrics, so the song title, artist, album and
+    platform id an AMLL database submission requires can only come from the
+    caller. Pass them and the file is submission-shaped; leave them out and you
+    get a valid TTML file without them.
     """
     body = []
     word_level = False
@@ -210,22 +212,42 @@ def to_ttml(aligned: list[AlignedLine], lang: str = "") -> str:
         else:
             inner = escape(a.line)
         body.append(f"{p_open}{inner}</p>")
+
+    placed = [a for a in aligned if not _skip(a)]
+    # The spec requires a parent's span to contain every child's, so the div and
+    # body take their bounds from the lines rather than from a nominal duration.
+    span_attrs = ""
+    if placed:
+        lo = min(a.start for a in placed)
+        hi = max(a.end for a in placed)
+        span_attrs = f' begin="{_ttml_ts(lo)}" end="{_ttml_ts(hi)}"'
+        body_dur = f' dur="{_ttml_ts(hi)}"'
+    else:
+        body_dur = ""
+
     lang_attr = f'\n    xml:lang="{escape(lang)}"' if lang else ""
+    amll_ns = ('\n    xmlns:amll="http://www.example.com/ns/amll"'
+               if meta else "")
+    meta_lines = "".join(
+        f'      <amll:meta key="{escape(str(k))}" value="{escape(str(v))}"/>\n'
+        for k, v in (meta or {}).items() if v not in (None, ""))
     timing = "Word" if word_level else "Line"
     return (
         '<?xml version="1.0" encoding="UTF-8"?>\n'
         '<tt xmlns="http://www.w3.org/ns/ttml"\n'
         '    xmlns:ttm="http://www.w3.org/ns/ttml#metadata"\n'
         '    xmlns:itunes="http://music.apple.com/lyric-ttml-internal"'
+        f'{amll_ns}'
         f'{lang_attr}\n'
         f'    itunes:timing="{timing}">\n'
         '  <head>\n'
         '    <metadata>\n'
         '      <ttm:agent type="person" xml:id="v1"/>\n'
+        f'{meta_lines}'
         '    </metadata>\n'
         '  </head>\n'
-        '  <body>\n'
-        '    <div>\n'
+        f'  <body{body_dur}>\n'
+        f'    <div{span_attrs}>\n'
         + "\n".join(body) + "\n"
         '    </div>\n'
         '  </body>\n'
@@ -275,14 +297,14 @@ def to_ass(aligned: list[AlignedLine], karaoke: bool = False) -> str:
 
 
 FORMATTERS = {
-    "json": lambda a, karaoke=False, lang="": to_json(a),
-    "lrc": lambda a, karaoke=False, lang="": to_lrc(a),
-    "elrc": lambda a, karaoke=False, lang="": to_elrc(a),
-    "srt": lambda a, karaoke=False, lang="": to_srt(a),
-    "vtt": lambda a, karaoke=False, lang="": to_vtt(a),
-    "ass": lambda a, karaoke=False, lang="": to_ass(a, karaoke=karaoke),
-    "ttml": lambda a, karaoke=False, lang="": to_ttml(a, lang=lang),
-    "aud": lambda a, karaoke=False, lang="": to_aud(a),
+    "json": lambda a, karaoke=False, lang="", meta=None: to_json(a),
+    "lrc": lambda a, karaoke=False, lang="", meta=None: to_lrc(a),
+    "elrc": lambda a, karaoke=False, lang="", meta=None: to_elrc(a),
+    "srt": lambda a, karaoke=False, lang="", meta=None: to_srt(a),
+    "vtt": lambda a, karaoke=False, lang="", meta=None: to_vtt(a),
+    "ass": lambda a, karaoke=False, lang="", meta=None: to_ass(a, karaoke=karaoke),
+    "ttml": lambda a, karaoke=False, lang="", meta=None: to_ttml(a, lang=lang, meta=meta),
+    "aud": lambda a, karaoke=False, lang="", meta=None: to_aud(a),
 }
 
 # Formats whose whole point is per-syllable timing, so the CLI computes character

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -129,6 +129,84 @@ def test_ttml_declares_an_agent_and_the_language():
     assert 'itunes:timing="Word"' in out
 
 
+def test_ttml_carries_the_metadata_an_amll_submission_needs():
+    # The AMLL TTML DB's checker (scripts/lyric_checker_bot/src/validator.rs)
+    # rejects a file that lacks musicName, artists, album, or any platform id.
+    # Those cannot be inferred from audio and lyrics, so they come from the
+    # caller — but when given, they have to land in the shape it reads.
+    meta = {"musicName": "黒砂の誓い", "artists": "屠龍",
+            "album": "SAMURAI SPIRITS DRILL", "spotifyId": "abc123"}
+    out = to_ttml([ja_line()], lang="ja", meta=meta)
+    assert 'xmlns:amll="http://www.example.com/ns/amll"' in out
+    for k, v in meta.items():
+        assert f'<amll:meta key="{k}" value="{v}"/>' in out
+    # Verified once against the AMLL reference parser: this exact shape reads
+    # back as {musicName, artists, album, spotifyId} and clears every rule the
+    # checker applies.
+
+
+def test_ttml_stays_clean_without_metadata():
+    # Nothing is invented when the caller says nothing: no amll namespace is
+    # declared if there is no amll metadata to put in it.
+    out = to_ttml([ja_line()], lang="ja")
+    assert "amll" not in out
+
+
+def test_ttml_body_and_div_contain_every_line():
+    # Same containment rule as spans-inside-p, one level up: a parent's span
+    # must contain its children's, or a strict player clamps them.
+    lines = [AlignedLine("島の左近", 3.0, 4.0, 0.9, True,
+                         char_timings("島の左近", WORDS_JA)),
+             AlignedLine("硫黄の島", 9.0, 12.5, 0.9, True, None)]
+    xml = to_ttml(lines)
+    div_begin, div_end = re.search(r'<div begin="([^"]+)" end="([^"]+)"', xml).groups()
+    assert div_begin == "00:00:03.000" and div_end == "00:00:12.500"
+    assert re.search(r'<body dur="([^"]+)"', xml).group(1) == div_end
+    for p_begin, p_end in re.findall(r'<p begin="([^"]+)" end="([^"]+)"', xml):
+        assert div_begin <= p_begin and p_end <= div_end
+
+
+def test_ttml_syllables_never_run_backwards():
+    # The checker rejects a syllable that starts before the previous one ended.
+    xml = to_ttml([en_line(), ja_line()])
+    for inner in re.findall(r"<p [^>]*>(.*?)</p>", xml):
+        spans = re.findall(r'<span begin="([^"]+)" end="([^"]+)"', inner)
+        for (_, prev_end), (begin, _) in zip(spans, spans[1:]):
+            assert begin >= prev_end
+
+
+def test_ttml_metadata_reaches_the_writer_from_the_cli(tmp_path, capsys):
+    from pathlib import Path
+
+    from lyric_align.cli import main
+    fix = Path(__file__).parent / "fixtures" / "segments_sample.json"
+    lyrics = tmp_path / "l.txt"
+    lyrics.write_text("あかねさす紫野ゆき\n")
+    out = tmp_path / "o.ttml"
+    assert main([str(lyrics), "--segments", str(fix), "--pairing", "1",
+                 "-f", "ttml", "-o", str(out),
+                 "--meta", "musicName=紫野", "--meta", "ncmMusicId=123"]) == 0
+    text = out.read_text()
+    assert '<amll:meta key="musicName" value="紫野"/>' in text
+    assert '<amll:meta key="ncmMusicId" value="123"/>' in text
+    capsys.readouterr()
+
+
+def test_ttml_metadata_rejects_a_malformed_pair(tmp_path, capsys):
+    from pathlib import Path
+
+    import pytest
+
+    from lyric_align.cli import main
+    fix = Path(__file__).parent / "fixtures" / "segments_sample.json"
+    lyrics = tmp_path / "l.txt"
+    lyrics.write_text("あかねさす紫野ゆき\n")
+    with pytest.raises(SystemExit):
+        main([str(lyrics), "--segments", str(fix), "-f", "ttml",
+              "-o", str(tmp_path / "o.ttml"), "--meta", "musicName"])
+    capsys.readouterr()
+
+
 def test_ttml_language_comes_from_the_cli(tmp_path, capsys):
     from lyric_align.cli import main
     from pathlib import Path


### PR DESCRIPTION
The [AMLL TTML DB](https://github.com/amll-dev/amll-ttml-db) is the largest open
collection of word-by-word lyric files — ~20k NetEase, ~14k Apple Music, ~14k
Spotify entries, timed by hand. It is the one place where this tool's output is
the thing people actually want, and until now our TTML could not be submitted.

Its checker requires `musicName`, `artists`, `album` and at least one platform
id. None of those can be inferred from audio and lyrics, which is exactly why
`to_ttml` left them out. The fix is to let the caller pass them — not to invent
them.

```bash
lyric-align song.wav lyrics.txt -f ttml -o out.ttml \
  --meta musicName="Song" --meta artists="Artist" --meta album="Album" \
  --meta ncmMusicId=1234567
```

## Everything structural was already right

Compared against a file already accepted into the database:

| | already in the DB | ours, before this PR |
|---|---|---|
| itunes namespace | `music.apple.com/lyric-ttml-internal` | same |
| line key | `itunes:key="L1"` | same |
| agent | `ttm:agent="v1"` | same |
| syllables | one `<span>` per CJK character | same |
| spaces | text nodes *between* spans | same (their spec calls this the most compliant form) |
| `amll:meta` | present | **missing** |
| `body dur` / `div begin`+`end` | present | **missing** |

So this PR adds the metadata block and the outer bounds. The bounds are derived
from the placed lines, which extends the containment rule we already enforced
for spans-inside-`p` up to `div` and `body`.

## Verified, not assumed

- Output parses with the AMLL reference parser (`@applemusic-like-lyrics/ttml`)
  and reads back as `{musicName, artists, album, spotifyId}` — 70 lines, 623
  syllables from the benchmark track.
- Clears every rule in the database's own checker, transcribed from
  `scripts/lyric_checker_bot/src/validator.rs`: the four metadata rules, non-zero
  timestamps, per-line content, `end >= start` at line and syllable level, and
  no syllable starting before the previous one ended.
- **Control**: the same file generated *without* `--meta` fails on exactly those
  four metadata rules. The check discriminates rather than passing everything.

6 tests added, 50 pass. No change to any other format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)