### PR TITLE
docs: variable unit size places more lines, and some of them badly

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,6 +284,15 @@ granularity) reproduces this: **33/33 matched, median |err| 0.30 s**, 26/33
 within 0.5 s. Its mean of 0.94 s comes almost entirely from four outliers, all on
 the *same* line — see below.
 
+The ground truth on both tracks is marked per two-line pair, so these figures
+score the *first* line of each pair — 20 and 33 lines, not every line placed.
+Second lines have a weaker but free check: each must start inside its pair's
+window. The shipped configuration passes it (19/19 and 29/33, the four misses
+being the repeated hook already described), so the tables are not hiding a second
+failure mode — but the distinction matters as soon as a change is judged on how
+many lines it places, because placements land mostly on the unscored half. One
+did, and it is the last entry in [Known limits](#known-limits).
+
 ### A bigger ASR model is a trap unless the pairing follows
 
 Lines are matched in stanza units, and `pairing` says how many lyric lines make
@@ -517,6 +526,44 @@ above, "Through many dangers, toils and snares" was placed on the line
   add lateness. A sung phrase begins at its breath and attack, before the first
   word the ASR is willing to timestamp, so the segment boundary is the better
   estimate of onset.
+- **A varying unit size places more lines, and some of them badly.** `pairing`
+  is a rounded average, so it is wrong for part of any track: at 76 lines over 64
+  segments the true ratio is 1.19, and a fixed 1 leaves 27 lines unplaced while a
+  fixed 2 straddles boundaries. Choosing `(lines, segment)` jointly at each step
+  fixes the placement count and looks nearly free on the shipped metric:
+
+  | unit size | lines placed | mean \|err\| | within 0.5 s | worst | 2nd lines outside their GT window |
+  |---|---|---|---|---|---|
+  | fixed, from the ASR (shipped) | 49/76 | **0.31 s** | **15/20** | **0.8 s** | **0 of 16** |
+  | variable, k ≤ 2 | 66/76 | 0.42 s | 14/20 | 2.0 s | 2 of 18 |
+  | variable, k ≤ 2, only if it wins by 0.1 | 66/76 | 0.32 s | **15/20** | **0.8 s** | 1 of 18 (by 13.3 s) |
+
+  The last column is the point. The other columns score only the *first* line of
+  each two-line ground-truth pair, which is where the extra placements do *not*
+  land — so on the shipped metric the third row is 17 free placements. Checking
+  the second lines, which have a known window to fall inside, shows what was
+  bought: the last verse line scores 0.000 against the hook segment on its own
+  and 0.286 once the following hook line is absorbed into the same unit, clearing
+  the 0.25 threshold, so it is placed 13.3 s late inside the hook — and the hook
+  line that had been correct is displaced with it. A unit picked to maximise
+  similarity will straddle a section boundary, and such a unit needs only its
+  tail to match; fixed pairing=1 cannot do this because a one-line unit has no
+  tail. Of the two extra placements that can be checked, one is right and one is
+  13.3 s wrong.
+
+  On a track where the ASR merges two lines consistently the same move fails
+  from the other side: deviating downward orphans the remaining line onto the
+  next segment and shifts every later unit's phase, taking within-0.5 s from
+  26/33 to 18/33 and landing the 4×-repeated hook a repetition early. Allowing
+  only *upward* deviation appears to fix that, but only because pairing=2 with
+  k ≤ 2 leaves upward no room — permitting k ≤ 3 breaks the same track again
+  (26/33 → 13/33).
+
+  This also disposes of the reason for trying it. The four attempts above all
+  changed which segment a unit selects, so the plan here was to change how much
+  a unit *consumes* and dodge that coupling. Consumption sets how fast the
+  segment cursor advances relative to the line cursor, so it moves `idx` as
+  well — one step removed, same result.
 - **Slow, sustained singing is much harder than rap** — hymns, ballads and
   school songs stretch vowels until the ASR stops producing usable segments.
   Reach for `--no-vad` first (see the one-minute example); dense, consonant-rich

--- a/src/lyric_align/anchor.py
+++ b/src/lyric_align/anchor.py
@@ -38,11 +38,41 @@ late (signed mean +0.46 s / +0.21 s) because a sung phrase begins at its breath
 and attack, earlier than the first word an ASR will timestamp, so refining into
 the segment only adds lateness. See the README for both tables.
 
+Letting the unit size vary — choosing, per step, how many lines this segment
+should absorb instead of fixing it up front — was tried next and also measured
+worse. It is a tempting move because `pairing` is a rounded average: at 76 lines
+over 64 segments the true ratio is 1.19, so a fixed 1 leaves 27 lines unplaced
+and a fixed 2 straddles boundaries. Scoring `(k, segment)` jointly does raise
+placements (49/76 -> 66/76), and the first-line error barely moves. It is not
+free: a unit chosen to maximise similarity will happily straddle a *section*
+boundary, and such a unit needs only its tail to match. On the first track the
+last verse line scores 0.000 against the hook segment alone and 0.286 once the
+following hook line joins it — over the 0.25 threshold — so the breath split
+drags that verse line 13.3 s forward into the hook, and displaces the correctly
+placed hook line as collateral. Fixed pairing cannot do this at pairing=1: a
+one-line unit has no tail to match with. Variable pairing manufactures the very
+tail-match pathology that a dedicated veto (above) already failed to fix.
+
+Note the shape of that failure, because it also refutes the reason for trying:
+the earlier four attempts all changed *selection* (which segment a unit takes),
+so the plan was to change *consumption* instead and avoid the coupling. It does
+not avoid it. Consumption sets how fast the segment cursor advances relative to
+the line cursor, so it moves `idx` too — just one step removed — and the same
+gains-and-losses-in-adjacent-pairs behaviour returns. On the second track, where
+the ASR merges two lines consistently, deviating downward orphans the remainder
+onto the next segment and shifts every later unit's phase: within-0.5 s falls
+26/33 -> 18/33 and the 4x-repeated hook lands a repetition early. Restricting
+deviation to *upward* only looks safe, but only because pairing=2 with k<=2
+leaves it no room; allowing k<=3 breaks that track the same way (26/33 -> 13/33).
+
 Design philosophy: when a line cannot be confidently matched, we mark it
 unmatched rather than inventing a timestamp. Forced aligners always emit an
 answer and thus fail *silently* (e.g. drifting into the intro); we prefer honest
 gaps that a human — or a later interpolation pass — can fix. The same reasoning
 rejects the global matcher above: a visible gap beats a confident wrong time.
+The variable-pairing result is the sharpest case: its headline gain was 17 extra
+placements, and on the only subset where those extra placements can be checked,
+half were catastrophically wrong.
 """
 from __future__ import annotations
 


### PR DESCRIPTION
The next idea after `--pairing auto`: stop fixing the unit size up front and choose `(lines, segment)` jointly at each step. `pairing` is a rounded average, so it is wrong for part of any track — at 76 lines over 64 segments the true ratio is 1.19, and a fixed 1 leaves 27 lines unplaced while a fixed 2 straddles boundaries.

**Measured worse. Documentation only, no behaviour change.**

## On the shipped metric it looks free

| unit size | lines placed | mean \|err\| | within 0.5 s | worst | 2nd lines outside their GT window |
|---|---|---|---|---|---|
| fixed, from the ASR (shipped) | 49/76 | **0.31 s** | **15/20** | **0.8 s** | **0 of 16** |
| variable, k ≤ 2 | 66/76 | 0.42 s | 14/20 | 2.0 s | 2 of 18 |
| variable, k ≤ 2, only if it wins by 0.1 | 66/76 | 0.32 s | **15/20** | **0.8 s** | 1 of 18 (by 13.3 s) |

The last column is the point. The ground truth is marked per two-line pair and the metric scores only the **first** line of each — which is exactly where the extra placements do *not* land. Second lines have a free check: each must start inside its pair's window.

## What the 17 "free" placements bought

The last verse line scores **0.000** against the hook segment on its own and **0.286** once the following hook line is absorbed into the same unit — over the 0.25 threshold. The breath split then drags that verse line 13.3 s forward into the hook, and displaces the hook line that had been placed correctly.

A unit chosen to maximise similarity will straddle a *section* boundary, and such a unit needs only its **tail** to match. `pairing=1` cannot do this because a one-line unit has no tail. So variable pairing manufactures the very tail-match pathology that the dedicated veto in Known limits already failed to fix.

Of the two extra placements that can be checked, one is right and one is 13.3 s wrong.

## It fails from the other side too

On a track where the ASR merges two lines consistently, deviating *downward* orphans the remaining line onto the next segment and shifts every later unit's phase: within-0.5 s 26/33 → 18/33, and the 4×-repeated hook lands a repetition early.

Restricting deviation to **upward only** appears to fix that — but only because `pairing=2` with `k ≤ 2` leaves upward no room. Allowing `k ≤ 3` breaks the same track again (26/33 → 13/33).

## Why the premise was wrong

The four earlier attempts all changed which segment a unit *selects*, so the plan here was to change how much a unit *consumes* and dodge that coupling. It does not dodge it: consumption sets how fast the segment cursor advances relative to the line cursor, so it moves `idx` as well — one step removed, same gains-and-losses-in-adjacent-pairs behaviour.

## Also disclosed

The Accuracy section now states that the headline figures score first lines only, and that the shipped configuration passes the second-line containment check (19/19 and 29/33, the four misses being the already-documented repeated hook). The tables were not hiding a second failure mode — but the distinction decides any change judged on placement count.

## Verification

57 tests pass. Harness in `toryu-web/scratchpad/lyrics_align_bench`: `exp_var_pairing.py`, `exp_var_diag.py`, `exp_var_rows.py`, `exp_var_margin.py`, `exp_var_updown.py`, `exp_second_line.py`. Every sweep endpoint (`m=inf`) reduces exactly to the shipped baseline on all four (track, model) configs — the first version did not, and that bug made the whole first sweep unreadable.